### PR TITLE
Customer-flow upgrades + Pirate Ship shipping

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,3 +18,24 @@ GLOBAL_ADMINS=user_id_1,user_id_2,user_id_3
 AIRTABLE_API_KEY=your_airtable_api_key_here
 AIRTABLE_BASE_ID=your_airtable_base_id_here
 AIRTABLE_TABLE_NAME=Projects
+
+# Transactional email (optional — sends are a safe no-op until configured).
+# EMAIL_PROVIDER is 'resend' or 'postmark'; set the matching key + a from address.
+EMAIL_PROVIDER=
+RESEND_API_KEY=
+POSTMARK_TOKEN=
+EMAIL_FROM=Hack Club Shop <shop@hackclub.com>
+ADMIN_ORDER_EMAIL=
+
+# Shipping / postage via Pirate Ship (runs on EasyPost). Optional — without a key,
+# fulfillment falls back to pasting a tracking number bought manually in Pirate Ship.
+EASYPOST_API_KEY=
+SHIP_FROM_NAME=Hack Club Shop
+SHIP_FROM_COMPANY=
+SHIP_FROM_STREET1=
+SHIP_FROM_STREET2=
+SHIP_FROM_CITY=
+SHIP_FROM_STATE=
+SHIP_FROM_ZIP=
+SHIP_FROM_COUNTRY=US
+SHIP_FROM_PHONE=

--- a/src/app/admin/orders/ShippingPanel.tsx
+++ b/src/app/admin/orders/ShippingPanel.tsx
@@ -1,0 +1,249 @@
+'use client';
+
+import { useState } from 'react';
+import { motion } from 'framer-motion';
+import { Order } from '../../../types/Order';
+import { ShippingRate } from '../../../lib/shipping';
+
+/**
+ * In-card shipping controls for an approved order: fetch EasyPost/Pirate Ship
+ * rates and buy a label, or record a tracking number bought manually in Pirate
+ * Ship. On success the parent gets the updated (now-fulfilled) order back.
+ */
+export default function ShippingPanel({
+    order,
+    onShipped,
+    onError,
+}: {
+    order: Order;
+    onShipped: (updated: Order) => void;
+    onError: (msg: string) => void;
+}) {
+    const [open, setOpen] = useState(false);
+    const [loadingRates, setLoadingRates] = useState(false);
+    const [configured, setConfigured] = useState<boolean | null>(null);
+    const [shipmentId, setShipmentId] = useState<string | null>(null);
+    const [rates, setRates] = useState<ShippingRate[]>([]);
+    const [buying, setBuying] = useState<string | null>(null);
+    const [mode, setMode] = useState<'rates' | 'manual'>('rates');
+
+    // Manual entry fields
+    const [carrier, setCarrier] = useState('USPS');
+    const [service, setService] = useState('');
+    const [trackingNumber, setTrackingNumber] = useState('');
+
+    const stop = (e: React.MouseEvent) => e.stopPropagation();
+
+    const fetchRates = async (e: React.MouseEvent) => {
+        stop(e);
+        setOpen(true);
+        if (!order.shippingAddress) {
+            setConfigured(false);
+            setMode('manual');
+            return;
+        }
+        setLoadingRates(true);
+        onError('');
+        try {
+            const res = await fetch(`/api/admin/orders/${order.id}/shipping`);
+            const data = await res.json();
+            setConfigured(Boolean(data.configured));
+            if (!data.configured) {
+                setMode('manual');
+            } else if (data.error) {
+                onError(data.error);
+                setMode('manual');
+            } else {
+                setShipmentId(data.shipmentId);
+                setRates(data.rates || []);
+                setMode('rates');
+            }
+        } catch {
+            onError('Could not fetch shipping rates');
+            setMode('manual');
+        } finally {
+            setLoadingRates(false);
+        }
+    };
+
+    const buy = async (rate: ShippingRate, e: React.MouseEvent) => {
+        stop(e);
+        setBuying(rate.id);
+        onError('');
+        try {
+            const res = await fetch(`/api/admin/orders/${order.id}/shipping`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ action: 'buy', shipmentId, rateId: rate.id }),
+            });
+            const data = await res.json();
+            if (!res.ok) {
+                onError(data.error || 'Label purchase failed');
+                return;
+            }
+            onShipped(data.order);
+            setOpen(false);
+        } catch {
+            onError('Label purchase failed');
+        } finally {
+            setBuying(null);
+        }
+    };
+
+    const recordManual = async (e: React.MouseEvent) => {
+        stop(e);
+        if (!trackingNumber.trim()) {
+            onError('Enter a tracking number');
+            return;
+        }
+        setBuying('manual');
+        onError('');
+        try {
+            const res = await fetch(`/api/admin/orders/${order.id}/shipping`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    action: 'manual',
+                    carrier: carrier || undefined,
+                    service: service || undefined,
+                    trackingNumber: trackingNumber.trim(),
+                }),
+            });
+            const data = await res.json();
+            if (!res.ok) {
+                onError(data.error || 'Could not save tracking');
+                return;
+            }
+            onShipped(data.order);
+            setOpen(false);
+        } catch {
+            onError('Could not save tracking');
+        } finally {
+            setBuying(null);
+        }
+    };
+
+    if (!open) {
+        return (
+            <button
+                type="button"
+                onClick={fetchRates}
+                className="px-4 py-2 rounded-xl text-sm font-bold text-white bg-hackclub-blue hover:bg-blue-600 transition-colors"
+            >
+                Ship &amp; fulfill
+            </button>
+        );
+    }
+
+    return (
+        <motion.div
+            initial={{ opacity: 0, height: 0 }}
+            animate={{ opacity: 1, height: 'auto' }}
+            onClick={stop}
+            className="mt-4 w-full p-4 rounded-xl border-2 border-hackclub-smoke bg-hackclub-snow"
+        >
+            <div className="flex items-center justify-between mb-3">
+                <p className="text-sm font-black text-hackclub-dark">Buy postage (Pirate Ship)</p>
+                <button type="button" onClick={(e) => { stop(e); setOpen(false); }} className="text-hackclub-muted hover:text-hackclub-dark text-sm font-bold">
+                    Close
+                </button>
+            </div>
+
+            <div className="flex gap-2 mb-4">
+                <button
+                    type="button"
+                    onClick={(e) => { stop(e); setMode('rates'); }}
+                    className={`px-3 py-1.5 rounded-full text-xs font-bold border-2 ${mode === 'rates' ? 'bg-hackclub-dark text-white border-hackclub-dark' : 'bg-white text-hackclub-slate border-hackclub-smoke'}`}
+                >
+                    Buy a label
+                </button>
+                <button
+                    type="button"
+                    onClick={(e) => { stop(e); setMode('manual'); }}
+                    className={`px-3 py-1.5 rounded-full text-xs font-bold border-2 ${mode === 'manual' ? 'bg-hackclub-dark text-white border-hackclub-dark' : 'bg-white text-hackclub-slate border-hackclub-smoke'}`}
+                >
+                    Enter tracking manually
+                </button>
+            </div>
+
+            {mode === 'rates' && (
+                <div>
+                    {loadingRates ? (
+                        <p className="text-sm text-hackclub-muted font-bold py-4">Fetching rates…</p>
+                    ) : configured === false ? (
+                        <p className="text-sm text-hackclub-slate py-2">
+                            EasyPost isn&apos;t configured. Buy the label in Pirate Ship and paste the tracking number under
+                            &ldquo;Enter tracking manually&rdquo;.
+                        </p>
+                    ) : rates.length === 0 ? (
+                        <p className="text-sm text-hackclub-slate py-2">No rates available for this address.</p>
+                    ) : (
+                        <div className="space-y-2">
+                            {rates.map((r) => (
+                                <div key={r.id} className="flex items-center justify-between bg-white rounded-lg border-2 border-hackclub-smoke px-3 py-2">
+                                    <div className="text-sm">
+                                        <span className="font-bold text-hackclub-dark">{r.carrier} {r.service}</span>
+                                        {r.estDeliveryDays != null && (
+                                            <span className="text-hackclub-muted"> · ~{r.estDeliveryDays}d</span>
+                                        )}
+                                    </div>
+                                    <div className="flex items-center gap-3">
+                                        <span className="font-black text-hackclub-dark">${r.rate.toFixed(2)}</span>
+                                        <button
+                                            type="button"
+                                            onClick={(e) => buy(r, e)}
+                                            disabled={buying !== null}
+                                            className="px-3 py-1.5 rounded-lg text-xs font-bold text-white bg-hackclub-green hover:bg-green-600 disabled:opacity-50"
+                                        >
+                                            {buying === r.id ? 'Buying…' : 'Buy'}
+                                        </button>
+                                    </div>
+                                </div>
+                            ))}
+                        </div>
+                    )}
+                </div>
+            )}
+
+            {mode === 'manual' && (
+                <div className="space-y-2">
+                    <div className="flex gap-2">
+                        <select
+                            value={carrier}
+                            onChange={(e) => setCarrier(e.target.value)}
+                            onClick={stop}
+                            className="rounded-lg border-2 border-hackclub-smoke px-3 py-2 text-sm font-bold text-hackclub-dark"
+                        >
+                            {['USPS', 'UPS', 'FedEx', 'DHL', 'Other'].map((c) => <option key={c}>{c}</option>)}
+                        </select>
+                        <input
+                            value={service}
+                            onChange={(e) => setService(e.target.value)}
+                            onClick={stop}
+                            placeholder="Service (optional)"
+                            className="flex-1 rounded-lg border-2 border-hackclub-smoke px-3 py-2 text-sm"
+                        />
+                    </div>
+                    <div className="flex gap-2">
+                        <input
+                            value={trackingNumber}
+                            onChange={(e) => setTrackingNumber(e.target.value)}
+                            onClick={stop}
+                            placeholder="Tracking number"
+                            className="flex-1 rounded-lg border-2 border-hackclub-smoke px-3 py-2 text-sm font-mono"
+                        />
+                        <button
+                            type="button"
+                            onClick={recordManual}
+                            disabled={buying !== null}
+                            className="px-4 py-2 rounded-lg text-sm font-bold text-white bg-hackclub-green hover:bg-green-600 disabled:opacity-50"
+                        >
+                            {buying === 'manual' ? 'Saving…' : 'Mark shipped'}
+                        </button>
+                    </div>
+                    <p className="text-xs text-hackclub-muted">The customer gets an email with this tracking link.</p>
+                </div>
+            )}
+        </motion.div>
+    );
+}

--- a/src/app/admin/orders/page.tsx
+++ b/src/app/admin/orders/page.tsx
@@ -13,6 +13,7 @@ export default function OrdersAdmin() {
     const [error, setError] = useState<string | null>(null);
     const [selectedOrder, setSelectedOrder] = useState<Order | null>(null);
     const [actingOrderId, setActingOrderId] = useState<string | null>(null);
+    const [showTest, setShowTest] = useState(false);
 
     useEffect(() => {
         if (status === 'unauthenticated') {
@@ -64,7 +65,7 @@ export default function OrdersAdmin() {
     const handleAction = async (
         e: React.MouseEvent,
         order: Order,
-        action: 'approve' | 'deny' | 'fulfill' | 'refund',
+        action: 'approve' | 'deny' | 'fulfill' | 'refund' | 'mark-test' | 'unmark-test',
     ) => {
         e.stopPropagation();
 
@@ -107,6 +108,8 @@ export default function OrdersAdmin() {
         );
     }
 
+    const visibleOrders = showTest ? orders : orders.filter((o) => !o.isTest);
+
     return (
         <div className="min-h-screen bg-white text-hackclub-dark"
             style={{
@@ -129,9 +132,21 @@ export default function OrdersAdmin() {
                     <h1 className="text-5xl sm:text-6xl font-black text-hackclub-dark mb-2">
                         Orders
                     </h1>
-                    <p className="text-lg text-hackclub-slate font-medium mb-12">
+                    <p className="text-lg text-hackclub-slate font-medium mb-6">
                         View and manage all orders
                     </p>
+
+                    <div className="mb-12">
+                        <button
+                            type="button"
+                            onClick={() => setShowTest((prev) => !prev)}
+                            className={`inline-flex items-center gap-2 px-4 py-2 rounded-full text-sm font-bold border-2 transition-colors ${showTest ? 'bg-hackclub-dark text-white border-hackclub-dark' : 'bg-white text-hackclub-slate border-hackclub-smoke hover:border-hackclub-slate'}`}
+                            aria-pressed={showTest}
+                        >
+                            <span className={`w-2 h-2 rounded-full ${showTest ? 'bg-hackclub-green' : 'bg-hackclub-muted'}`} />
+                            Show test orders
+                        </button>
+                    </div>
 
                     {error && (
                         <motion.div
@@ -145,7 +160,7 @@ export default function OrdersAdmin() {
 
                     <div className="space-y-4">
                         <AnimatePresence initial={false} mode="popLayout">
-                            {orders.length === 0 ? (
+                            {visibleOrders.length === 0 ? (
                                 <motion.div
                                     initial={{ opacity: 0 }}
                                     animate={{ opacity: 1 }}
@@ -154,7 +169,7 @@ export default function OrdersAdmin() {
                                     <p className="text-hackclub-muted font-bold">No orders yet</p>
                                 </motion.div>
                             ) : (
-                                orders.map((order, index) => (
+                                visibleOrders.map((order, index) => (
                                     <motion.div
                                         key={order.id}
                                         initial={{ opacity: 0, y: 20 }}
@@ -169,6 +184,11 @@ export default function OrdersAdmin() {
                                                 <p className="text-xs text-hackclub-slate">{order.pathway === 'guest' ? `Guest: ${order.guestEmail || '—'}` : `User: ${order.userId}`}</p>
                                             </div>
                                             <div className="flex items-center gap-2">
+                                                {order.isTest && (
+                                                    <span className="px-2.5 py-1 rounded-full text-xs font-bold bg-gray-100 text-gray-600">
+                                                        TEST
+                                                    </span>
+                                                )}
                                                 {order.pathway && (
                                                     <span className={`px-2.5 py-1 rounded-full text-xs font-bold ${order.pathway === 'guest' ? 'bg-purple-100 text-purple-800' : 'bg-cyan-100 text-cyan-800'}`}>
                                                         {order.pathway === 'guest' ? 'Card' : 'Points'}
@@ -217,7 +237,8 @@ export default function OrdersAdmin() {
                                                 actions.push({ action: 'refund', label: refundLabel, className: 'bg-hackclub-red hover:bg-red-600' });
                                             }
 
-                                            if (actions.length === 0) return null;
+                                            const testAction: 'mark-test' | 'unmark-test' = order.isTest ? 'unmark-test' : 'mark-test';
+                                            const testLabel = order.isTest ? 'Untest' : 'Mark test';
 
                                             return (
                                                 <div className="mt-4 flex flex-wrap gap-2">
@@ -232,6 +253,14 @@ export default function OrdersAdmin() {
                                                             {isActing ? 'Working…' : label}
                                                         </button>
                                                     ))}
+                                                    <button
+                                                        type="button"
+                                                        onClick={(e) => handleAction(e, order, testAction)}
+                                                        disabled={isActing}
+                                                        className="px-4 py-2 rounded-xl text-sm font-bold bg-gray-100 text-gray-600 hover:bg-gray-200 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                                                    >
+                                                        {isActing ? 'Working…' : testLabel}
+                                                    </button>
                                                 </div>
                                             );
                                         })()}

--- a/src/app/api/admin/me/route.ts
+++ b/src/app/api/admin/me/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '../../auth/[...nextauth]/route';
+import { getAdminRole, getAdminPermissions } from '../../../../lib/adminAuth';
+
+/**
+ * Lightweight "am I an admin?" check for client UI (the nav link, the dashboard
+ * gate). Returns the current user's admin role + permissions, or isAdmin:false.
+ * Always 200 so the client can read the flag without treating 403 as an error.
+ */
+export async function GET() {
+    const session = await getServerSession(authOptions);
+    const userId = session?.user?.id;
+    if (!userId) {
+        return NextResponse.json({ isAdmin: false });
+    }
+
+    const role = await getAdminRole(userId);
+    if (!role) {
+        return NextResponse.json({ isAdmin: false });
+    }
+
+    const permissions = await getAdminPermissions(userId);
+    return NextResponse.json({ isAdmin: true, role, permissions });
+}

--- a/src/app/api/admin/orders/[id]/route.ts
+++ b/src/app/api/admin/orders/[id]/route.ts
@@ -15,8 +15,9 @@ const redis = new Redis({
     token: process.env.UPSTASH_REDIS_REST_TOKEN!,
 });
 
-type Action = 'approve' | 'deny' | 'fulfill' | 'refund';
-const ACTION_STATUS: Record<Action, Order['status']> = {
+type StatusAction = 'approve' | 'deny' | 'fulfill' | 'refund';
+type Action = StatusAction | 'mark-test' | 'unmark-test';
+const ACTION_STATUS: Record<StatusAction, Order['status']> = {
     approve: 'approved',
     deny: 'denied',
     fulfill: 'fulfilled',
@@ -42,9 +43,26 @@ export async function POST(request: Request, { params }: { params: { id: string 
     const orderId = params.id;
     const { action, message } = (await request.json()) as { action: Action; message?: string };
 
-    if (!action || !(action in ACTION_STATUS)) {
+    const isTestToggle = action === 'mark-test' || action === 'unmark-test';
+    if (!action || (!isTestToggle && !(action in ACTION_STATUS))) {
         return NextResponse.json({ error: 'Invalid action' }, { status: 400 });
     }
+
+    // Test-flag toggle: a simple field flip, no status/refund/email side effects.
+    if (isTestToggle) {
+        const isTest = action === 'mark-test';
+        const guest = await getGuestOrder(orderId);
+        if (guest) {
+            const updated = await updateGuestOrder(orderId, { isTest });
+            if (updated) void mirrorOrder(updated);
+            return NextResponse.json({ order: updated });
+        }
+        const updated = await setStudentOrderField(orderId, { isTest });
+        if (!updated) return NextResponse.json({ error: 'Order not found' }, { status: 404 });
+        void mirrorOrder(updated);
+        return NextResponse.json({ order: updated });
+    }
+
     const newStatus = ACTION_STATUS[action];
 
     try {
@@ -156,4 +174,19 @@ function extractEmail(order: Order): string | undefined {
         if (typeof v === 'string' && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v)) return v;
     }
     return undefined;
+}
+
+/** Patch arbitrary fields on a student order in its user order array. */
+async function setStudentOrderField(orderId: string, patch: Partial<Order>): Promise<Order | null> {
+    const keys = await redis.keys('user:*:orders');
+    for (const key of keys) {
+        const orders = (await redis.get<Order[]>(key)) || [];
+        const idx = orders.findIndex(o => o.id === orderId);
+        if (idx === -1) continue;
+        const updated: Order = { ...orders[idx], ...patch };
+        orders[idx] = updated;
+        await redis.set(key, orders);
+        return updated;
+    }
+    return null;
 }

--- a/src/app/api/admin/orders/[id]/shipping/route.ts
+++ b/src/app/api/admin/orders/[id]/shipping/route.ts
@@ -1,0 +1,155 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '../../../../auth/[...nextauth]/route';
+import { requireAdminPermission } from '../../../../../../lib/adminAuth';
+import { findOrder, patchOrder, orderEmail } from '../../../../../../lib/orderStore';
+import { mirrorOrder } from '../../../../../../lib/airtableMirror';
+import { sendEmail, buildStatusUpdate } from '../../../../../../lib/email';
+import {
+    getRates,
+    buyLabel,
+    isShippingConfigured,
+    fallbackTrackingUrl,
+    ParcelSpec,
+} from '../../../../../../lib/shipping';
+import { recordAudit } from '../../../../../../lib/auditLog';
+import { OrderShipment, OrderStatusUpdate } from '../../../../../../types/Order';
+
+/**
+ * Shipping / postage actions for one order (Pirate Ship ⇄ EasyPost).
+ *
+ *   GET  → fetch buyable rates for the order's destination address.
+ *   POST { action: 'buy', rateId?, shipmentId, parcel? }
+ *        → buy postage, persist tracking to the order, mark it fulfilled,
+ *          email the customer with the tracking link.
+ *   POST { action: 'manual', carrier?, service?, trackingNumber }
+ *        → record a tracking number bought manually in Pirate Ship, same
+ *          fulfillment + email side effects, no EasyPost call.
+ *
+ * Gated on canManageBalance to match the rest of order management.
+ */
+
+function historyEntry(message?: string): OrderStatusUpdate {
+    return { status: 'fulfilled', timestamp: new Date(), ...(message ? { message } : {}) };
+}
+
+export async function GET(request: Request, { params }: { params: { id: string } }) {
+    const session = await getServerSession(authOptions);
+    const can = await requireAdminPermission(session, 'canManageBalance');
+    if (!can.allowed) return NextResponse.json({ error: 'Unauthorized' }, { status: 403 });
+
+    if (!isShippingConfigured()) {
+        return NextResponse.json({ configured: false, rates: [] });
+    }
+
+    const order = await findOrder(params.id);
+    if (!order) return NextResponse.json({ error: 'Order not found' }, { status: 404 });
+    if (!order.shippingAddress) {
+        return NextResponse.json({ error: 'Order has no structured shipping address' }, { status: 400 });
+    }
+
+    const url = new URL(request.url);
+    const parcel: ParcelSpec = {
+        weightOz: numParam(url, 'weightOz'),
+        lengthIn: numParam(url, 'lengthIn'),
+        widthIn: numParam(url, 'widthIn'),
+        heightIn: numParam(url, 'heightIn'),
+    };
+
+    const result = await getRates(order.shippingAddress, parcel);
+    if (!result.ok) {
+        return NextResponse.json(
+            { configured: true, rates: [], error: result.message || 'Could not fetch rates' },
+            { status: result.reason === 'not_configured' ? 200 : 502 },
+        );
+    }
+    return NextResponse.json({ configured: true, shipmentId: result.shipmentId, rates: result.rates });
+}
+
+export async function POST(request: Request, { params }: { params: { id: string } }) {
+    const session = await getServerSession(authOptions);
+    const can = await requireAdminPermission(session, 'canManageBalance');
+    if (!can.allowed) return NextResponse.json({ error: 'Unauthorized' }, { status: 403 });
+
+    const order = await findOrder(params.id);
+    if (!order) return NextResponse.json({ error: 'Order not found' }, { status: 404 });
+
+    const body = (await request.json()) as {
+        action: 'buy' | 'manual';
+        rateId?: string;
+        shipmentId?: string;
+        carrier?: string;
+        service?: string;
+        trackingNumber?: string;
+        message?: string;
+    };
+
+    let shipment: OrderShipment;
+
+    if (body.action === 'buy') {
+        if (!body.shipmentId) {
+            return NextResponse.json({ error: 'shipmentId is required to buy a label' }, { status: 400 });
+        }
+        const bought = await buyLabel(body.shipmentId, body.rateId);
+        if (!bought.ok) {
+            return NextResponse.json(
+                { error: bought.message || 'Label purchase failed' },
+                { status: bought.reason === 'not_configured' ? 400 : 502 },
+            );
+        }
+        shipment = {
+            carrier: bought.carrier,
+            service: bought.service,
+            trackingNumber: bought.trackingNumber,
+            trackingUrl: bought.trackingUrl || (bought.trackingNumber ? fallbackTrackingUrl(bought.carrier, bought.trackingNumber) : undefined),
+            labelUrl: bought.labelUrl,
+            easypostShipmentId: bought.shipmentId,
+            cost: bought.cost,
+            estDeliveryDate: bought.estDeliveryDate,
+            shippedAt: new Date(),
+        };
+    } else if (body.action === 'manual') {
+        if (!body.trackingNumber) {
+            return NextResponse.json({ error: 'trackingNumber is required' }, { status: 400 });
+        }
+        shipment = {
+            carrier: body.carrier,
+            service: body.service,
+            trackingNumber: body.trackingNumber,
+            trackingUrl: fallbackTrackingUrl(body.carrier, body.trackingNumber),
+            shippedAt: new Date(),
+        };
+    } else {
+        return NextResponse.json({ error: 'Invalid action' }, { status: 400 });
+    }
+
+    // Buying postage fulfills the order: persist shipment + flip status.
+    const updated = await patchOrder(params.id, {
+        shipment,
+        status: 'fulfilled',
+        statusHistory: [...(order.statusHistory || []), historyEntry(body.message)],
+    });
+    if (!updated) return NextResponse.json({ error: 'Order not found' }, { status: 404 });
+
+    void mirrorOrder(updated);
+    const to = orderEmail(updated);
+    if (to) void sendEmail(buildStatusUpdate(updated, to, body.message));
+
+    void recordAudit({
+        action: 'order.ship',
+        actorId: session?.user?.id || 'unknown',
+        actorEmail: session?.user?.email || undefined,
+        target: params.id,
+        summary: `Shipped order #${params.id.slice(-8)} via ${shipment.carrier || 'manual'}${shipment.trackingNumber ? ` (${shipment.trackingNumber})` : ''}`,
+        metadata: { mode: body.action, carrier: shipment.carrier, trackingNumber: shipment.trackingNumber, cost: shipment.cost },
+    });
+
+    return NextResponse.json({ order: updated });
+}
+
+function numParam(url: URL, key: string): number | undefined {
+    const v = url.searchParams.get(key);
+    if (v == null || v === '') return undefined;
+    const n = parseFloat(v);
+    return Number.isFinite(n) ? n : undefined;
+}

--- a/src/app/api/admin/stats/route.ts
+++ b/src/app/api/admin/stats/route.ts
@@ -65,15 +65,20 @@ export async function GET(request: Request) {
             filteredOrders = orders.filter(o => new Date(o.createdAt) >= startDate);
         }
 
-        totalOrders = filteredOrders.length;
-        totalRevenue = filteredOrders.reduce((sum, o) => sum + o.totalAmount, 0);
+        // Aggregates (revenue, counts, top products) exclude test orders so junk
+        // doesn't pollute the numbers. The full list — including test orders — is
+        // still returned for the admin page to optionally show.
+        const realOrders = filteredOrders.filter(o => !o.isTest);
 
-        filteredOrders.forEach(order => {
+        totalOrders = realOrders.length;
+        totalRevenue = realOrders.reduce((sum, o) => sum + o.totalAmount, 0);
+
+        realOrders.forEach(order => {
             ordersByStatus[order.status] = (ordersByStatus[order.status] || 0) + 1;
         });
 
         const productSales: Record<string, { name: string; quantity: number; revenue: number }> = {};
-        filteredOrders.forEach(order => {
+        realOrders.forEach(order => {
             order.items.forEach(item => {
                 const productName = item.name;
                 if (!productSales[productName]) {

--- a/src/app/api/cart/route.ts
+++ b/src/app/api/cart/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { Redis } from '@upstash/redis';
+import { authOptions } from '../auth/[...nextauth]/route';
+
+/**
+ * Per-student server-side cart, so a logged-in hack clubber's cart follows them
+ * across devices. Guests are not persisted here — their cart stays in
+ * localStorage only (no account to key on). The client treats this as a sync
+ * target, not the source of truth, and still clears the cart on confirmed
+ * checkout success exactly as before.
+ */
+
+const redis = new Redis({
+    url: process.env.UPSTASH_REDIS_REST_URL!,
+    token: process.env.UPSTASH_REDIS_REST_TOKEN!,
+});
+
+const key = (userId: string) => `user:${userId}:cart`;
+
+export async function GET() {
+    const session = await getServerSession(authOptions);
+    const userId = session?.user?.id;
+    if (!userId) return NextResponse.json({ cart: null });
+    const cart = (await redis.get(key(userId))) ?? null;
+    return NextResponse.json({ cart });
+}
+
+export async function PUT(request: Request) {
+    const session = await getServerSession(authOptions);
+    const userId = session?.user?.id;
+    if (!userId) return NextResponse.json({ ok: false }, { status: 401 });
+
+    const body = (await request.json().catch(() => ({}))) as { cart?: unknown };
+    const cart = Array.isArray(body.cart) ? body.cart.slice(0, 100) : [];
+    await redis.set(key(userId), cart);
+    return NextResponse.json({ ok: true });
+}

--- a/src/app/api/orders/lookup/route.ts
+++ b/src/app/api/orders/lookup/route.ts
@@ -1,0 +1,62 @@
+import { NextResponse } from 'next/server';
+import { lookupGuestOrder } from '../../../../lib/guestOrders';
+import { rateLimit, rateLimitResponse } from '../../../../lib/rateLimit';
+
+/**
+ * Public guest order-status lookup. Guests have no account, so they prove
+ * ownership with the email used at checkout + the order ref from their
+ * confirmation email. Returns a sanitized view (status, items, tracking) —
+ * never internal fields like the Stripe payment intent or raw checkout data.
+ *
+ * Rate-limited per IP to prevent enumeration of order ids against an email.
+ */
+export async function POST(request: Request) {
+    const ip = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || 'unknown';
+    const limit = await rateLimit(`order-lookup:${ip}`, { maxRequests: 10, windowMs: 60_000 });
+    if (!limit.success) return rateLimitResponse();
+
+    const { email, orderRef } = (await request.json().catch(() => ({}))) as {
+        email?: string;
+        orderRef?: string;
+    };
+    if (!email || !orderRef) {
+        return NextResponse.json({ error: 'Email and order number are required.' }, { status: 400 });
+    }
+
+    const order = await lookupGuestOrder(email, orderRef);
+    // Same response shape whether the order is missing or the email doesn't match,
+    // so the endpoint can't be used to confirm which orders exist for an email.
+    if (!order) {
+        return NextResponse.json({ error: 'No order found for that email and order number.' }, { status: 404 });
+    }
+
+    return NextResponse.json({
+        order: {
+            id: order.id,
+            ref: order.id.slice(-8),
+            status: order.status,
+            paymentStatus: order.paymentStatus,
+            createdAt: order.createdAt,
+            items: order.items.map(i => ({
+                name: i.name,
+                quantity: i.quantity,
+                price: i.price,
+                thumbnail_url: i.thumbnail_url,
+            })),
+            totalAmount: order.totalAmount,
+            shippingAddress: order.shippingAddress
+                ? { city: order.shippingAddress.city, state: order.shippingAddress.state, country: order.shippingAddress.country }
+                : undefined,
+            shipment: order.shipment
+                ? {
+                      carrier: order.shipment.carrier,
+                      service: order.shipment.service,
+                      trackingNumber: order.shipment.trackingNumber,
+                      trackingUrl: order.shipment.trackingUrl,
+                      estDeliveryDate: order.shipment.estDeliveryDate,
+                  }
+                : undefined,
+            statusHistory: (order.statusHistory || []).map(s => ({ status: s.status, timestamp: s.timestamp, message: s.message })),
+        },
+    });
+}

--- a/src/app/checkout/page.tsx
+++ b/src/app/checkout/page.tsx
@@ -253,9 +253,9 @@ const Checkout = () => {
                 initial={{ opacity: 0, scale: 0.96, y: 24 }}
                 animate={{ opacity: 1, scale: 1, y: 0 }}
                 transition={{ duration: 0.35, type: 'spring', stiffness: 180, damping: 18 }}
-                className="w-full max-w-6xl mx-auto bg-white text-hackclub-dark rounded-3xl shadow-2xl border border-hackclub-smoke overflow-hidden"
+                className="w-full max-w-6xl mx-auto bg-white text-hackclub-dark rounded-2xl sm:rounded-3xl shadow-2xl border border-hackclub-smoke overflow-hidden"
             >
-                <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 p-8">
+                <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 sm:gap-8 p-5 sm:p-8">
                     {/* LEFT COLUMN */}
                     <div className="space-y-6">
                         <div>
@@ -422,8 +422,17 @@ const Checkout = () => {
 
                         <AnimatePresence>
                             {error && (
-                                <motion.div initial={{ opacity: 0, y: -10 }} animate={{ opacity: 1, y: 0 }} exit={{ opacity: 0, y: -10 }} className="p-3 bg-hackclub-red/10 border-2 border-hackclub-red rounded-xl">
+                                <motion.div initial={{ opacity: 0, y: -10 }} animate={{ opacity: 1, y: 0 }} exit={{ opacity: 0, y: -10 }} className="p-3 bg-hackclub-red/10 border-2 border-hackclub-red rounded-xl flex items-center justify-between gap-3">
                                     <p className="text-hackclub-red font-bold text-sm">{error}</p>
+                                    {canCheckout && !loading && (
+                                        <button
+                                            type="button"
+                                            onClick={handleCheckout}
+                                            className="shrink-0 text-xs font-black text-white bg-hackclub-red hover:bg-hackclub-orange px-3 py-1.5 rounded-full transition-colors"
+                                        >
+                                            Try again
+                                        </button>
+                                    )}
                                 </motion.div>
                             )}
                         </AnimatePresence>
@@ -438,8 +447,9 @@ const Checkout = () => {
                         >
                             <AnimatePresence mode="wait" initial={false}>
                                 {loading ? (
-                                    <motion.span key="processing" initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}>
-                                        <span className="inline-block animate-pulse">{isStudent ? 'Processing…' : 'Redirecting to payment…'}</span>
+                                    <motion.span key="processing" initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} className="inline-flex items-center justify-center gap-2">
+                                        <span className="inline-block w-5 h-5 border-[3px] border-white/40 border-t-white rounded-full animate-spin" aria-hidden="true" />
+                                        {isStudent ? 'Processing…' : 'Redirecting to payment…'}
                                     </motion.span>
                                 ) : canCheckout ? (
                                     <motion.span key="checkout" initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}>

--- a/src/app/components/Navigation.tsx
+++ b/src/app/components/Navigation.tsx
@@ -73,10 +73,25 @@ const Navigation = () => {
   const [shouldAnimateCart, setShouldAnimateCart] = useState(false);
   const [isInitialMount, setIsInitialMount] = useState(true);
   const [showUserMenu, setShowUserMenu] = useState(false);
+  const [isAdmin, setIsAdmin] = useState(false);
 
   useEffect(() => {
     setIsClient(true);
   }, []);
+
+  // Resolve admin status for the current user (drives the Admin nav link + badge).
+  useEffect(() => {
+    if (status !== 'authenticated') {
+      setIsAdmin(false);
+      return;
+    }
+    let cancelled = false;
+    fetch('/api/admin/me')
+      .then((res) => res.json())
+      .then((data) => { if (!cancelled) setIsAdmin(Boolean(data?.isAdmin)); })
+      .catch(() => { if (!cancelled) setIsAdmin(false); });
+    return () => { cancelled = true; };
+  }, [status]);
 
   useEffect(() => {
     if (cartContext?.totalPrice !== undefined) {
@@ -173,6 +188,15 @@ const Navigation = () => {
                   Orders
                 </Link>
               )}
+
+              {session && isAdmin && (
+                <Link
+                  href="/admin"
+                  className="text-hackclub-red hover:text-hackclub-orange font-bold text-xl transition-colors flex items-center gap-1.5"
+                >
+                  Admin
+                </Link>
+              )}
             </div>
 
             <div className="flex items-center gap-4">
@@ -203,11 +227,27 @@ const Navigation = () => {
                   </button>
 
                   {showUserMenu && (
-                    <div className="absolute right-0 mt-2 w-48 bg-white rounded-lg shadow-lg border border-gray-200 py-2 z-50">
+                    <div className="absolute right-0 mt-2 w-56 bg-white rounded-lg shadow-lg border border-gray-200 py-2 z-50">
                       <div className="px-4 py-2 border-b border-gray-100">
-                        <p className="font-bold text-hackclub-dark truncate">{session.user?.name}</p>
+                        <div className="flex items-center gap-2">
+                          <p className="font-bold text-hackclub-dark truncate">{session.user?.name}</p>
+                          {isAdmin && (
+                            <span className="text-[10px] font-black uppercase tracking-wide bg-hackclub-red/10 text-hackclub-red px-1.5 py-0.5 rounded">
+                              Admin
+                            </span>
+                          )}
+                        </div>
                         <p className="text-sm text-hackclub-slate truncate">{session.user?.email}</p>
                       </div>
+                      {isAdmin && (
+                        <Link
+                          href="/admin"
+                          onClick={() => setShowUserMenu(false)}
+                          className="block px-4 py-2 text-hackclub-dark hover:bg-gray-50 font-bold transition-colors"
+                        >
+                          Admin Dashboard
+                        </Link>
+                      )}
                       <button
                         onClick={() => signOut()}
                         className="w-full text-left px-4 py-2 text-hackclub-red hover:bg-gray-50 font-bold transition-colors"

--- a/src/app/orders/page.tsx
+++ b/src/app/orders/page.tsx
@@ -1,17 +1,22 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useContext } from 'react';
+import { useRouter } from 'next/navigation';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useSession, signIn } from 'next-auth/react';
 import Image from 'next/image';
 import { Order } from '../../types/Order';
 import { OrderSkeleton } from '../components/Skeleton';
+import { CartContext } from '../../context/CartContext';
 
 const OrdersPage = () => {
     const { data: session, status } = useSession();
+    const router = useRouter();
+    const cart = useContext(CartContext);
     const [orders, setOrders] = useState<Order[]>([]);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
+    const [reordering, setReordering] = useState<string | null>(null);
 
     useEffect(() => {
         const fetchOrders = async () => {
@@ -62,6 +67,57 @@ const OrdersPage = () => {
                 return 'bg-orange-100 text-orange-800';
             default:
                 return 'bg-gray-100 text-gray-800';
+        }
+    };
+
+    // Reorder: re-fetch each product so prices/availability are current and
+    // correct for whichever pathway the shopper is on (the stored order item only
+    // carries the historical USD price — points orders store "0"). Falls back to
+    // the stored price if the product can't be re-fetched. addToCart increments by
+    // one, so add once per unit.
+    const handleReorder = async (order: Order) => {
+        if (!cart) return;
+        setReordering(order.id);
+        try {
+            // De-dupe product lookups across items in the order.
+            const productCache: Record<string, any> = {};
+            for (const item of order.items) {
+                const productId = String(item.id);
+                if (!(productId in productCache)) {
+                    try {
+                        const res = await fetch(`/api/products/${productId}`);
+                        const data = res.ok ? await res.json() : null;
+                        productCache[productId] = data?.result || null;
+                    } catch {
+                        productCache[productId] = null;
+                    }
+                }
+                const result = productCache[productId];
+                const variant = result?.sync_variants?.find((v: any) => v.name === item.name) || result?.sync_variants?.[0];
+
+                const cartItem = variant
+                    ? {
+                          id: productId,
+                          name: variant.name,
+                          price: String(variant.price_cash ?? 0),
+                          price_cash: variant.price_cash || undefined,
+                          price_points: variant.price_points || undefined,
+                          thumbnail_url: variant.product?.image || item.thumbnail_url || '',
+                          variant_id: variant.variant_id || variant.id,
+                      }
+                    : {
+                          id: productId,
+                          name: item.name,
+                          price: item.price,
+                          price_cash: parseFloat(item.price) || undefined,
+                          thumbnail_url: item.thumbnail_url || '',
+                      };
+
+                for (let i = 0; i < item.quantity; i++) cart.addToCart(cartItem);
+            }
+            router.push('/shop?reordered=1');
+        } finally {
+            setReordering(null);
         }
     };
 
@@ -252,6 +308,48 @@ const OrdersPage = () => {
                                                  </div>
                                              ) : null}
                                          </div>
+
+                                        {order.shipment?.trackingNumber && (
+                                            <div className="px-6 py-4 border-t-2 border-hackclub-smoke">
+                                                <div className="rounded-xl bg-hackclub-snow border-2 border-hackclub-smoke px-4 py-3 flex flex-wrap items-center justify-between gap-3">
+                                                    <div>
+                                                        <p className="text-xs font-bold text-hackclub-muted uppercase">
+                                                            📦 Shipped{order.shipment.carrier ? ` · ${order.shipment.carrier}${order.shipment.service ? ` ${order.shipment.service}` : ''}` : ''}
+                                                        </p>
+                                                        <p className="font-mono text-sm text-hackclub-dark">{order.shipment.trackingNumber}</p>
+                                                        {order.shipment.estDeliveryDate && (
+                                                            <p className="text-xs text-hackclub-slate mt-0.5">Est. delivery: {order.shipment.estDeliveryDate}</p>
+                                                        )}
+                                                    </div>
+                                                    {order.shipment.trackingUrl && (
+                                                        <a
+                                                            href={order.shipment.trackingUrl}
+                                                            target="_blank"
+                                                            rel="noreferrer"
+                                                            className="bg-hackclub-red hover:bg-hackclub-orange text-white font-bold text-sm py-2 px-4 rounded-full transition-colors whitespace-nowrap"
+                                                        >
+                                                            Track package →
+                                                        </a>
+                                                    )}
+                                                </div>
+                                            </div>
+                                        )}
+
+                                        {cart && order.items.length > 0 && (
+                                            <div className="px-6 py-4 border-t-2 border-hackclub-smoke">
+                                                <button
+                                                    type="button"
+                                                    onClick={() => handleReorder(order)}
+                                                    disabled={reordering === order.id}
+                                                    className="inline-flex items-center gap-2 text-hackclub-blue hover:text-hackclub-dark font-bold text-sm transition-colors disabled:opacity-50"
+                                                >
+                                                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                                                    </svg>
+                                                    {reordering === order.id ? 'Adding to cart…' : 'Reorder these items'}
+                                                </button>
+                                            </div>
+                                        )}
 
                                         {order.statusHistory && order.statusHistory.length > 0 && (
                                             <div className="px-6 py-4 border-t-2 border-hackclub-smoke space-y-2">

--- a/src/app/orders/track/page.tsx
+++ b/src/app/orders/track/page.tsx
@@ -1,0 +1,211 @@
+'use client';
+
+import { Suspense, useEffect, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
+import Link from 'next/link';
+import { motion } from 'framer-motion';
+
+interface LookupItem {
+    name: string;
+    quantity: number;
+    price: string;
+    thumbnail_url?: string;
+}
+interface LookupShipment {
+    carrier?: string;
+    service?: string;
+    trackingNumber?: string;
+    trackingUrl?: string;
+    estDeliveryDate?: string;
+}
+interface LookupOrder {
+    id: string;
+    ref: string;
+    status: string;
+    paymentStatus: string;
+    createdAt: string;
+    items: LookupItem[];
+    totalAmount: number;
+    shippingAddress?: { city: string; state: string; country: string };
+    shipment?: LookupShipment;
+    statusHistory: { status: string; timestamp: string; message?: string }[];
+}
+
+const STATUS_COLOR: Record<string, string> = {
+    pending: 'bg-yellow-100 text-yellow-800',
+    approved: 'bg-blue-100 text-blue-800',
+    fulfilled: 'bg-green-100 text-green-800',
+    denied: 'bg-red-100 text-red-800',
+    refunded: 'bg-orange-100 text-orange-800',
+};
+
+const gridBg = {
+    backgroundImage:
+        'linear-gradient(to right, #e0f2fe 1px, transparent 1px), linear-gradient(to bottom, #e0f2fe 1px, transparent 1px)',
+    backgroundSize: '30px 30px',
+};
+
+const TrackInner = () => {
+    const params = useSearchParams();
+    const [email, setEmail] = useState(params.get('email') || '');
+    const [orderRef, setOrderRef] = useState(params.get('ref') || '');
+    const [order, setOrder] = useState<LookupOrder | null>(null);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    const lookup = async (e?: React.FormEvent) => {
+        e?.preventDefault();
+        if (!email.trim() || !orderRef.trim()) {
+            setError('Enter your email and order number.');
+            return;
+        }
+        setLoading(true);
+        setError(null);
+        setOrder(null);
+        try {
+            const res = await fetch('/api/orders/lookup', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ email: email.trim(), orderRef: orderRef.trim() }),
+            });
+            const data = await res.json();
+            if (!res.ok) {
+                setError(data.error || 'Lookup failed.');
+                return;
+            }
+            setOrder(data.order);
+        } catch {
+            setError('Lookup failed. Please try again.');
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    // Auto-run the lookup if the email link prefilled both fields.
+    useEffect(() => {
+        if (params.get('email') && params.get('ref')) {
+            lookup();
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    return (
+        <div className="min-h-screen bg-white text-hackclub-dark" style={gridBg}>
+            <div className="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+                <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.4 }}>
+                    <h1 className="text-4xl sm:text-5xl font-black text-hackclub-dark mb-2">Track your order</h1>
+                    <p className="text-lg text-hackclub-slate font-medium mb-8">
+                        Enter the email and order number from your confirmation email.
+                    </p>
+
+                    <form onSubmit={lookup} className="bg-white rounded-2xl shadow-lg border-2 border-hackclub-smoke p-6 space-y-4">
+                        <div>
+                            <label htmlFor="track-email" className="block text-sm font-bold text-hackclub-slate mb-1">Email</label>
+                            <input
+                                id="track-email"
+                                type="email"
+                                value={email}
+                                onChange={(e) => setEmail(e.target.value)}
+                                placeholder="you@example.com"
+                                className="w-full rounded-xl border-2 border-hackclub-smoke px-4 py-2.5 focus:border-hackclub-blue focus:outline-none"
+                            />
+                        </div>
+                        <div>
+                            <label htmlFor="track-ref" className="block text-sm font-bold text-hackclub-slate mb-1">Order number</label>
+                            <input
+                                id="track-ref"
+                                value={orderRef}
+                                onChange={(e) => setOrderRef(e.target.value)}
+                                placeholder="e.g. 1a2b3c4d"
+                                className="w-full rounded-xl border-2 border-hackclub-smoke px-4 py-2.5 font-mono focus:border-hackclub-blue focus:outline-none"
+                            />
+                        </div>
+                        <button
+                            type="submit"
+                            disabled={loading}
+                            className="w-full bg-hackclub-red hover:bg-hackclub-orange text-white font-black py-3 rounded-full transition-colors disabled:opacity-50"
+                        >
+                            {loading ? 'Looking up…' : 'Find my order'}
+                        </button>
+                    </form>
+
+                    {error && (
+                        <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="mt-6 p-4 bg-hackclub-red/10 border-2 border-hackclub-red/30 rounded-xl text-center">
+                            <p className="text-hackclub-red font-bold">{error}</p>
+                        </motion.div>
+                    )}
+
+                    {order && (
+                        <motion.div
+                            initial={{ opacity: 0, y: 16 }}
+                            animate={{ opacity: 1, y: 0 }}
+                            className="mt-6 bg-white rounded-2xl shadow-lg border-2 border-hackclub-smoke overflow-hidden"
+                        >
+                            <div className="px-6 py-4 border-b-2 border-hackclub-smoke flex items-center justify-between">
+                                <div>
+                                    <p className="text-sm text-hackclub-muted font-bold">Order #{order.ref}</p>
+                                    <p className="text-xs text-hackclub-slate">{new Date(order.createdAt).toLocaleDateString()}</p>
+                                </div>
+                                <span className={`px-3 py-1 rounded-full text-xs font-bold capitalize ${STATUS_COLOR[order.status] || 'bg-gray-100 text-gray-800'}`}>
+                                    {order.status}
+                                </span>
+                            </div>
+
+                            <div className="px-6 py-4 space-y-3">
+                                {order.items.map((item, i) => (
+                                    <div key={i} className="flex items-center justify-between text-sm">
+                                        <span className="font-bold text-hackclub-dark">{item.quantity}× {item.name}</span>
+                                        <span className="text-hackclub-slate">${(parseFloat(item.price) * item.quantity).toFixed(2)}</span>
+                                    </div>
+                                ))}
+                                <div className="flex justify-between pt-2 border-t border-hackclub-smoke">
+                                    <span className="font-bold text-hackclub-slate">Total</span>
+                                    <span className="font-black text-hackclub-dark">${order.totalAmount.toFixed(2)}</span>
+                                </div>
+                            </div>
+
+                            {order.shipment?.trackingNumber && (
+                                <div className="px-6 py-4 border-t-2 border-hackclub-smoke">
+                                    <div className="rounded-xl bg-hackclub-snow border-2 border-hackclub-smoke px-4 py-3 flex flex-wrap items-center justify-between gap-3">
+                                        <div>
+                                            <p className="text-xs font-bold text-hackclub-muted uppercase">
+                                                📦 Shipped{order.shipment.carrier ? ` · ${order.shipment.carrier}${order.shipment.service ? ` ${order.shipment.service}` : ''}` : ''}
+                                            </p>
+                                            <p className="font-mono text-sm text-hackclub-dark">{order.shipment.trackingNumber}</p>
+                                            {order.shipment.estDeliveryDate && (
+                                                <p className="text-xs text-hackclub-slate mt-0.5">Est. delivery: {order.shipment.estDeliveryDate}</p>
+                                            )}
+                                        </div>
+                                        {order.shipment.trackingUrl && (
+                                            <a
+                                                href={order.shipment.trackingUrl}
+                                                target="_blank"
+                                                rel="noreferrer"
+                                                className="bg-hackclub-red hover:bg-hackclub-orange text-white font-bold text-sm py-2 px-4 rounded-full transition-colors whitespace-nowrap"
+                                            >
+                                                Track package →
+                                            </a>
+                                        )}
+                                    </div>
+                                </div>
+                            )}
+                        </motion.div>
+                    )}
+
+                    <p className="text-center text-sm text-hackclub-muted mt-8">
+                        Signed in with Hack Club?{' '}
+                        <Link href="/orders" className="text-hackclub-blue font-bold hover:underline">See all your orders</Link>
+                    </p>
+                </motion.div>
+            </div>
+        </div>
+    );
+};
+
+const TrackPage = () => (
+    <Suspense fallback={<div className="min-h-screen bg-white flex items-center justify-center text-hackclub-dark font-bold">Loading…</div>}>
+        <TrackInner />
+    </Suspense>
+);
+
+export default TrackPage;

--- a/src/app/thank-you/page.tsx
+++ b/src/app/thank-you/page.tsx
@@ -79,7 +79,12 @@ const ThankYouInner = () => {
       {status === 'paid' && (
         <p className="text-hackclub-muted mb-8">A confirmation has been sent to your email.</p>
       )}
-      <Link href="/shop" className="inline-block bg-hackclub-red hover:bg-hackclub-orange text-white font-bold px-8 py-3 rounded-full shadow-lg transition-colors">Continue Shopping</Link>
+      <div className="flex flex-wrap items-center justify-center gap-3">
+        <Link href="/shop" className="inline-block bg-hackclub-red hover:bg-hackclub-orange text-white font-bold px-8 py-3 rounded-full shadow-lg transition-colors">Continue Shopping</Link>
+        {isGuest && status === 'paid' && (
+          <Link href="/orders/track" className="inline-block border-2 border-hackclub-smoke hover:border-hackclub-slate text-hackclub-slate font-bold px-8 py-3 rounded-full transition-colors">Track your order</Link>
+        )}
+      </div>
     </div>
   );
 };

--- a/src/context/CartContext.tsx
+++ b/src/context/CartContext.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import React, { createContext, useState, useEffect } from 'react';
+import React, { createContext, useState, useEffect, useRef } from 'react';
+import { useSession } from 'next-auth/react';
 
 interface CartItem {
     id: string | number;
@@ -26,17 +27,76 @@ export const CartContext = createContext<CartContextType | undefined>(undefined)
 
 export const CartProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
     const [cart, setCart] = useState<CartItem[] | null>(null);
+    const { data: session, status } = useSession();
+    const userId = session?.user?.id;
+    // Tracks which user's server cart we've already merged in, so the one-time
+    // login merge doesn't re-run on every render or overwrite later edits.
+    const mergedForUser = useRef<string | null>(null);
+    const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
     useEffect(() => {
         const savedCart = JSON.parse(localStorage.getItem('cart') || '[]') as CartItem[];
         setCart(savedCart);
     }, []);
 
+    // localStorage stays the always-on store (and the only store for guests).
     useEffect(() => {
         if (cart !== null) {
             localStorage.setItem('cart', JSON.stringify(cart));
         }
     }, [cart]);
+
+    // On login, reconcile with the student's server-side cart so it follows them
+    // across devices: a non-empty server cart wins (cross-device continuity); an
+    // empty server cart adopts whatever the guest had locally (carry-over).
+    useEffect(() => {
+        if (status !== 'authenticated' || !userId) {
+            if (status === 'unauthenticated') mergedForUser.current = null;
+            return;
+        }
+        if (mergedForUser.current === userId || cart === null) return;
+        mergedForUser.current = userId;
+
+        let cancelled = false;
+        (async () => {
+            try {
+                const res = await fetch('/api/cart');
+                const data = await res.json();
+                if (cancelled) return;
+                const serverCart = Array.isArray(data.cart) ? (data.cart as CartItem[]) : null;
+                if (serverCart && serverCart.length > 0) {
+                    setCart(serverCart);
+                } else if (cart.length > 0) {
+                    // Push the local cart up so this device's items persist server-side.
+                    void fetch('/api/cart', {
+                        method: 'PUT',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ cart }),
+                    });
+                }
+            } catch {
+                // Network/Redis hiccup — localStorage cart remains intact.
+            }
+        })();
+        return () => { cancelled = true; };
+    }, [status, userId, cart]);
+
+    // Debounced push of cart changes to the server for logged-in students. This
+    // also propagates clearCart() (an empty array) — keeping the clear-on-success
+    // behaviour identical across devices.
+    useEffect(() => {
+        if (status !== 'authenticated' || !userId || cart === null) return;
+        if (mergedForUser.current !== userId) return; // wait until the initial merge ran
+        if (saveTimer.current) clearTimeout(saveTimer.current);
+        saveTimer.current = setTimeout(() => {
+            void fetch('/api/cart', {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ cart }),
+            });
+        }, 600);
+        return () => { if (saveTimer.current) clearTimeout(saveTimer.current); };
+    }, [cart, status, userId]);
 
     const addToCart = (item: Omit<CartItem, 'quantity'>) => {
         setCart((prevCart) => {

--- a/src/lib/airtableMirror.ts
+++ b/src/lib/airtableMirror.ts
@@ -129,6 +129,12 @@ export function mirrorProduct(product: Product): Promise<void> {
             'Variants JSON': JSON.stringify(product.variants || []),
             'Shipping Options JSON': JSON.stringify(product.shippingOptions || []),
             'Variant Count': (product.variants || []).length,
+            // Convenience roll-up so staff can scan stock without parsing the JSON.
+            // Per-variant stock lives inside Variants JSON (the sync reads it there).
+            'Total Stock': (product.variants || []).reduce(
+                (sum, v) => sum + (typeof v.stock === 'number' ? v.stock : 0),
+                0,
+            ),
             'Updated At': new Date().toISOString(),
         }),
     );
@@ -163,6 +169,9 @@ export function mirrorOrder(order: Order, slackId?: string): Promise<void> {
             'Shipping Country': order.shippingCountry || '',
             'Shipping Address': order.shippingAddress ? formatAddress(order.shippingAddress) : '',
             'Shipping Address JSON': order.shippingAddress ? JSON.stringify(order.shippingAddress) : '',
+            Carrier: order.shipment?.carrier || '',
+            'Tracking Number': order.shipment?.trackingNumber || '',
+            'Tracking URL': order.shipment?.trackingUrl || '',
             'Checkout Data JSON': JSON.stringify(order.checkoutData || {}),
             'Status History JSON': JSON.stringify(order.statusHistory || []),
             'Created At': new Date(order.createdAt).toISOString(),

--- a/src/lib/airtableMirror.ts
+++ b/src/lib/airtableMirror.ts
@@ -150,6 +150,7 @@ export function mirrorOrder(order: Order, slackId?: string): Promise<void> {
             'Payment Method': order.paymentMethod,
             'Payment Status': order.paymentStatus,
             'Guest Email': order.guestEmail || '',
+            'Is Test': order.isTest ? true : false,
             Status: order.status,
             'Items JSON': JSON.stringify(order.items || []),
             'Item Summary': (order.items || []).map((i) => `${i.quantity}x ${i.name}`).join(', '),

--- a/src/lib/auditLog.ts
+++ b/src/lib/auditLog.ts
@@ -1,0 +1,84 @@
+import { Redis } from '@upstash/redis';
+
+/**
+ * Lightweight admin audit log for money/points/stock-affecting actions.
+ *
+ * These are real-value operations (refunds, point grants, order status changes,
+ * shipping labels, stock edits), so we keep an append-only trail of who did what,
+ * when, to which target. Stored as a capped Redis list (`audit:log`) — newest
+ * first, trimmed to the most recent N entries so it never grows unbounded.
+ *
+ * Fire-and-forget like the other side-effect layers: `void recordAudit(...)`.
+ * A logging failure must never break the action it's recording.
+ */
+
+const redis = new Redis({
+    url: process.env.UPSTASH_REDIS_REST_URL!,
+    token: process.env.UPSTASH_REDIS_REST_TOKEN!,
+});
+
+const KEY = 'audit:log';
+const MAX_ENTRIES = 1000;
+
+export type AuditAction =
+    | 'order.approve'
+    | 'order.deny'
+    | 'order.fulfill'
+    | 'order.refund'
+    | 'order.mark-test'
+    | 'order.unmark-test'
+    | 'order.ship'
+    | 'points.grant'
+    | 'points.deduct'
+    | 'inventory.adjust';
+
+export interface AuditEntry {
+    id: string;
+    action: AuditAction;
+    actorId: string;          // admin user id
+    actorEmail?: string;
+    target?: string;          // order id / user id / variant id
+    summary: string;          // human-readable one-liner
+    metadata?: Record<string, unknown>;
+    timestamp: string;        // ISO
+}
+
+/** Append an audit entry. Never throws. */
+export async function recordAudit(
+    entry: Omit<AuditEntry, 'id' | 'timestamp'> & { timestamp?: string },
+): Promise<void> {
+    try {
+        const full: AuditEntry = {
+            id: `audit_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`,
+            timestamp: entry.timestamp || new Date().toISOString(),
+            ...entry,
+        };
+        await redis.lpush(KEY, JSON.stringify(full));
+        await redis.ltrim(KEY, 0, MAX_ENTRIES - 1);
+    } catch (err) {
+        console.error('[audit] record failed:', err instanceof Error ? err.message : err);
+    }
+}
+
+/** Read the most recent audit entries (newest first). */
+export async function readAudit(limit = 100): Promise<AuditEntry[]> {
+    try {
+        const raw = await redis.lrange<string | AuditEntry>(KEY, 0, Math.max(0, limit - 1));
+        return raw
+            .map((r) => {
+                if (typeof r === 'string') {
+                    try {
+                        return JSON.parse(r) as AuditEntry;
+                    } catch {
+                        return null;
+                    }
+                }
+                // Upstash may auto-deserialize JSON values.
+                return r as AuditEntry;
+            })
+            .filter((e): e is AuditEntry => Boolean(e && e.id));
+    } catch (err) {
+        console.error('[audit] read failed:', err instanceof Error ? err.message : err);
+        return [];
+    }
+}

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -15,6 +15,9 @@ import { formatAddress } from './address';
 
 const FROM = process.env.EMAIL_FROM || 'Hack Club Shop <shop@hackclub.com>';
 const ADMIN_EMAIL = process.env.ADMIN_ORDER_EMAIL; // staff inbox for new-order alerts
+// Public base URL for links in emails (no request context here). Falls back
+// through the URLs already configured for the app.
+const BASE_URL = (process.env.NEXT_PUBLIC_API_URL || process.env.NEXTAUTH_URL || 'https://shop.hackclub.com').replace(/\/$/, '');
 
 export interface EmailMessage {
     to: string;
@@ -115,13 +118,24 @@ function shell(title: string, bodyHtml: string): string {
 /** Order confirmation to the customer (works for both guest + student orders). */
 export function buildOrderConfirmation(order: Order, to: string): EmailMessage {
     const ref = order.id.slice(-8);
-    const text = `Thanks for your order!\n\nOrder #${ref}\n\nItems:\n${itemsText(order)}\n\n${priceLine(order)}\nShipping to: ${shippingLine(order)}\n\nWe'll let you know when it ships.`;
+
+    // Guests have no account; give them a self-serve status link prefilled with
+    // their email + order ref. Students track orders from /orders while signed in.
+    const trackUrl =
+        order.pathway === 'guest'
+            ? `${BASE_URL}/orders/track?email=${encodeURIComponent(to)}&ref=${encodeURIComponent(ref)}`
+            : `${BASE_URL}/orders`;
+    const trackText = `\n\nTrack your order: ${trackUrl}`;
+    const trackHtml = `<p style="margin-top:16px"><a href="${escapeHtml(trackUrl)}" style="display:inline-block;background:#ec3750;color:#fff;text-decoration:none;font-weight:700;padding:10px 20px;border-radius:999px">Track your order →</a></p>`;
+
+    const text = `Thanks for your order!\n\nOrder #${ref}\n\nItems:\n${itemsText(order)}\n\n${priceLine(order)}\nShipping to: ${shippingLine(order)}\n\nWe'll let you know when it ships.${trackText}`;
     const html = shell('Thanks for your order!', `
         <p>Your order <strong>#${ref}</strong> is confirmed.</p>
         <ul>${itemsHtml(order)}</ul>
         <p><strong>${escapeHtml(priceLine(order))}</strong></p>
         <p style="color:#8492a6">Shipping to: ${escapeHtml(shippingLine(order))}</p>
-        <p>We'll email you again when it ships.</p>`);
+        <p>We'll email you again when it ships.</p>
+        ${trackHtml}`);
     return { to, subject: `Your Hack Club Shop order #${ref}`, html, text };
 }
 
@@ -151,10 +165,28 @@ export function buildStatusUpdate(order: Order, to: string, message?: string): E
     };
     const line = map[order.status] || `Your order status is now: ${order.status}.`;
     const reason = message ? `\n\nNote: ${message}` : '';
-    const text = `Order #${ref}\n\n${line}${reason}`;
+
+    // When the order shipped with a tracking number, surface it prominently.
+    const ship = order.status === 'fulfilled' ? order.shipment : undefined;
+    const carrierLabel = ship?.carrier ? `${ship.carrier}${ship.service ? ` ${ship.service}` : ''}` : '';
+    const eta = ship?.estDeliveryDate ? `\nEstimated delivery: ${ship.estDeliveryDate}` : '';
+    const trackText = ship?.trackingNumber
+        ? `\n\nTracking${carrierLabel ? ` (${carrierLabel})` : ''}: ${ship.trackingNumber}${ship.trackingUrl ? `\n${ship.trackingUrl}` : ''}${eta}`
+        : '';
+
+    const text = `Order #${ref}\n\n${line}${reason}${trackText}`;
+    const trackHtml = ship?.trackingNumber
+        ? `<div style="margin-top:16px;padding:14px 16px;background:#f9fafc;border-radius:10px">
+            <p style="margin:0 0 6px;font-weight:700">Tracking${carrierLabel ? ` — ${escapeHtml(carrierLabel)}` : ''}</p>
+            <p style="margin:0 0 10px;font-family:monospace">${escapeHtml(ship.trackingNumber)}</p>
+            ${ship.trackingUrl ? `<a href="${escapeHtml(ship.trackingUrl)}" style="display:inline-block;background:#ec3750;color:#fff;text-decoration:none;font-weight:700;padding:8px 16px;border-radius:999px">Track your package →</a>` : ''}
+            ${ship.estDeliveryDate ? `<p style="margin:10px 0 0;color:#8492a6;font-size:13px">Estimated delivery: ${escapeHtml(ship.estDeliveryDate)}</p>` : ''}
+        </div>`
+        : '';
     const html = shell(`Order #${ref} update`, `
         <p>${escapeHtml(line)}</p>
-        ${message ? `<p style="color:#8492a6">Note: ${escapeHtml(message)}</p>` : ''}`);
+        ${message ? `<p style="color:#8492a6">Note: ${escapeHtml(message)}</p>` : ''}
+        ${trackHtml}`);
     return { to, subject: `Update on your order #${ref}`, html, text };
 }
 

--- a/src/lib/guestOrders.ts
+++ b/src/lib/guestOrders.ts
@@ -47,6 +47,22 @@ export async function getGuestOrderBySession(sessionId: string): Promise<Order |
     return getGuestOrder(orderId);
 }
 
+/**
+ * Look up a guest order by email + order id, for the public order-status page.
+ * Both must match: the email proves ownership (no auth), the id selects the order.
+ * Accepts the full id or the 8-char short ref shown to customers.
+ */
+export async function lookupGuestOrder(email: string, orderRef: string): Promise<Order | null> {
+    const ids = (await redis.get<string[]>(emailKey(email))) || [];
+    const ref = orderRef.trim().toLowerCase();
+    for (const id of ids) {
+        if (id.toLowerCase() === ref || id.slice(-8).toLowerCase() === ref) {
+            return getGuestOrder(id);
+        }
+    }
+    return null;
+}
+
 /** Patch an existing guest order in place (e.g. mark paid from the webhook). */
 export async function updateGuestOrder(orderId: string, patch: Partial<Order>): Promise<Order | null> {
     const existing = await getGuestOrder(orderId);

--- a/src/lib/orderStore.ts
+++ b/src/lib/orderStore.ts
@@ -1,0 +1,62 @@
+import { Redis } from '@upstash/redis';
+import { Order } from '../types/Order';
+import { getGuestOrder, updateGuestOrder } from './guestOrders';
+
+/**
+ * Cross-pathway order lookup/patch helpers.
+ *
+ * Guest (Stripe) orders are standalone under `order:${id}`. Student (points)
+ * orders live inside arrays under `user:${userId}:orders`. Admin tooling that
+ * acts on "an order by id" — fulfillment, shipping labels, status changes —
+ * needs to resolve either shape, so that logic lives here once.
+ */
+
+const redis = new Redis({
+    url: process.env.UPSTASH_REDIS_REST_URL!,
+    token: process.env.UPSTASH_REDIS_REST_TOKEN!,
+});
+
+/** Look up any order by id, guest or student. */
+export async function findOrder(orderId: string): Promise<Order | null> {
+    const guest = await getGuestOrder(orderId);
+    if (guest) return guest;
+    const keys = await redis.keys('user:*:orders');
+    for (const key of keys) {
+        const orders = (await redis.get<Order[]>(key)) || [];
+        const found = orders.find(o => o.id === orderId);
+        if (found) return found;
+    }
+    return null;
+}
+
+/**
+ * Patch arbitrary fields on any order by id (guest or student) and return the
+ * updated order, or null if not found. Does not send emails or mirror — callers
+ * decide on side effects.
+ */
+export async function patchOrder(orderId: string, patch: Partial<Order>): Promise<Order | null> {
+    const guest = await getGuestOrder(orderId);
+    if (guest) {
+        return updateGuestOrder(orderId, patch);
+    }
+    const keys = await redis.keys('user:*:orders');
+    for (const key of keys) {
+        const orders = (await redis.get<Order[]>(key)) || [];
+        const idx = orders.findIndex(o => o.id === orderId);
+        if (idx === -1) continue;
+        const updated: Order = { ...orders[idx], ...patch };
+        orders[idx] = updated;
+        await redis.set(key, orders);
+        return updated;
+    }
+    return null;
+}
+
+/** Best-effort email for an order: explicit guest email, else a checkoutData email. */
+export function orderEmail(order: Order): string | undefined {
+    if (order.guestEmail) return order.guestEmail;
+    for (const v of Object.values(order.checkoutData || {})) {
+        if (typeof v === 'string' && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v)) return v;
+    }
+    return undefined;
+}

--- a/src/lib/shipping.ts
+++ b/src/lib/shipping.ts
@@ -1,0 +1,239 @@
+/**
+ * Shipping / postage layer for the shop — the "Pirate Ship" integration.
+ *
+ * Pirate Ship is a free front-end over the EasyPost carrier network: it has no
+ * public REST API of its own, but the exact same labels and discounted rates are
+ * available through EasyPost, which Pirate Ship is built on. So "integrate Pirate
+ * Ship" here means: talk to EasyPost to fetch rates, buy postage labels, and get
+ * tracking numbers. Staff who prefer the Pirate Ship web UI can still buy a label
+ * there and paste the tracking number in — both paths land in `Order.shipment`.
+ *
+ * Provider-agnostic and safe by design, like `email.ts` and `airtableMirror.ts`:
+ *   - No SDK; plain `fetch` against the EasyPost v2 REST API with Basic auth.
+ *   - When EASYPOST_API_KEY is unset, every call returns a typed "not configured"
+ *     result instead of throwing, so fulfillment still works with manual tracking.
+ *
+ * To go live: set EASYPOST_API_KEY (test key starts `EZTK`, prod `EZAK`) and the
+ * SHIP_FROM_* env vars for the origin address postage ships from.
+ */
+
+import { ShippingAddress } from '../types/Order';
+
+const API_BASE = 'https://api.easypost.com/v2';
+
+export function isShippingConfigured(): boolean {
+    return Boolean(process.env.EASYPOST_API_KEY);
+}
+
+/** Origin address postage ships from, read from env (the Hack Club warehouse). */
+function fromAddress() {
+    return {
+        name: process.env.SHIP_FROM_NAME || 'Hack Club Shop',
+        company: process.env.SHIP_FROM_COMPANY,
+        street1: process.env.SHIP_FROM_STREET1,
+        street2: process.env.SHIP_FROM_STREET2,
+        city: process.env.SHIP_FROM_CITY,
+        state: process.env.SHIP_FROM_STATE,
+        zip: process.env.SHIP_FROM_ZIP,
+        country: process.env.SHIP_FROM_COUNTRY || 'US',
+        phone: process.env.SHIP_FROM_PHONE,
+    };
+}
+
+function authHeader(): string {
+    // EasyPost uses HTTP Basic auth: API key as the username, empty password.
+    const key = process.env.EASYPOST_API_KEY || '';
+    return `Basic ${Buffer.from(`${key}:`).toString('base64')}`;
+}
+
+async function easypost<T>(path: string, init: RequestInit): Promise<T> {
+    const res = await fetch(`${API_BASE}${path}`, {
+        ...init,
+        headers: {
+            Authorization: authHeader(),
+            'Content-Type': 'application/json',
+            ...(init.headers || {}),
+        },
+    });
+    if (!res.ok) {
+        const body = (await res.text()).slice(0, 300);
+        throw new Error(`EasyPost ${res.status} on ${path}: ${body}`);
+    }
+    return res.json() as Promise<T>;
+}
+
+/** Map our ShippingAddress to EasyPost's address shape. */
+function toEasyPostAddress(addr: ShippingAddress) {
+    return {
+        name: addr.name,
+        street1: addr.line1,
+        street2: addr.line2 || undefined,
+        city: addr.city,
+        state: addr.state,
+        zip: addr.postal_code,
+        country: addr.country,
+    };
+}
+
+export interface ParcelSpec {
+    /** ounces; EasyPost wants weight in oz. Defaults to a light flat-pack. */
+    weightOz?: number;
+    lengthIn?: number;
+    widthIn?: number;
+    heightIn?: number;
+}
+
+export interface ShippingRate {
+    id: string;          // EasyPost rate id, passed back to buyLabel
+    carrier: string;
+    service: string;
+    rate: number;        // USD
+    estDeliveryDays?: number;
+    shipmentId: string;
+}
+
+export type RatesResult =
+    | { ok: true; shipmentId: string; rates: ShippingRate[] }
+    | { ok: false; reason: 'not_configured' | 'error'; message?: string };
+
+export type BuyLabelResult =
+    | {
+          ok: true;
+          carrier: string;
+          service: string;
+          trackingNumber: string;
+          trackingUrl?: string;
+          labelUrl?: string;
+          shipmentId: string;
+          cost?: number;
+          estDeliveryDate?: string;
+      }
+    | { ok: false; reason: 'not_configured' | 'error'; message?: string };
+
+interface EpRate {
+    id: string;
+    carrier: string;
+    service: string;
+    rate: string;
+    delivery_days?: number | null;
+}
+interface EpShipment {
+    id: string;
+    rates: EpRate[];
+    tracking_code?: string;
+    selected_rate?: EpRate;
+    postage_label?: { label_url?: string };
+    tracker?: { public_url?: string; est_delivery_date?: string };
+}
+
+/**
+ * Create an EasyPost shipment for an order's destination and return buyable
+ * rates. Never throws — returns a typed failure so the admin UI can fall back to
+ * manual tracking entry.
+ */
+export async function getRates(to: ShippingAddress, parcel: ParcelSpec = {}): Promise<RatesResult> {
+    if (!isShippingConfigured()) return { ok: false, reason: 'not_configured' };
+    try {
+        const shipment = await easypost<EpShipment>('/shipments', {
+            method: 'POST',
+            body: JSON.stringify({
+                shipment: {
+                    to_address: toEasyPostAddress(to),
+                    from_address: fromAddress(),
+                    parcel: {
+                        weight: parcel.weightOz ?? 6,
+                        length: parcel.lengthIn,
+                        width: parcel.widthIn,
+                        height: parcel.heightIn,
+                    },
+                },
+            }),
+        });
+        const rates: ShippingRate[] = (shipment.rates || [])
+            .map(r => ({
+                id: r.id,
+                carrier: r.carrier,
+                service: r.service,
+                rate: parseFloat(r.rate),
+                estDeliveryDays: r.delivery_days ?? undefined,
+                shipmentId: shipment.id,
+            }))
+            .sort((a, b) => a.rate - b.rate);
+        return { ok: true, shipmentId: shipment.id, rates };
+    } catch (err) {
+        console.error('[shipping] getRates failed:', err instanceof Error ? err.message : err);
+        return { ok: false, reason: 'error', message: err instanceof Error ? err.message : 'rate lookup failed' };
+    }
+}
+
+/**
+ * Buy postage for a shipment+rate. Returns tracking + label details to persist on
+ * the order. If `rateId` is omitted, buys the cheapest available rate.
+ */
+export async function buyLabel(shipmentId: string, rateId?: string): Promise<BuyLabelResult> {
+    if (!isShippingConfigured()) return { ok: false, reason: 'not_configured' };
+    try {
+        let chosenRateId = rateId;
+        if (!chosenRateId) {
+            const current = await easypost<EpShipment>(`/shipments/${shipmentId}`, { method: 'GET' });
+            const cheapest = (current.rates || []).slice().sort((a, b) => parseFloat(a.rate) - parseFloat(b.rate))[0];
+            if (!cheapest) return { ok: false, reason: 'error', message: 'no rates available for shipment' };
+            chosenRateId = cheapest.id;
+        }
+        const bought = await easypost<EpShipment>(`/shipments/${shipmentId}/buy`, {
+            method: 'POST',
+            body: JSON.stringify({ rate: { id: chosenRateId } }),
+        });
+        return {
+            ok: true,
+            carrier: bought.selected_rate?.carrier || '',
+            service: bought.selected_rate?.service || '',
+            trackingNumber: bought.tracking_code || '',
+            trackingUrl: bought.tracker?.public_url,
+            labelUrl: bought.postage_label?.label_url,
+            shipmentId: bought.id,
+            cost: bought.selected_rate ? parseFloat(bought.selected_rate.rate) : undefined,
+            estDeliveryDate: bought.tracker?.est_delivery_date,
+        };
+    } catch (err) {
+        console.error('[shipping] buyLabel failed:', err instanceof Error ? err.message : err);
+        return { ok: false, reason: 'error', message: err instanceof Error ? err.message : 'label purchase failed' };
+    }
+}
+
+/**
+ * Refund unused postage (e.g. a label bought then cancelled). Best-effort; never
+ * throws. EasyPost only refunds labels that were never scanned by the carrier.
+ */
+export async function refundLabel(shipmentId: string): Promise<boolean> {
+    if (!isShippingConfigured()) return false;
+    try {
+        await easypost(`/shipments/${shipmentId}/refund`, { method: 'POST' });
+        return true;
+    } catch (err) {
+        console.error('[shipping] refundLabel failed:', err instanceof Error ? err.message : err);
+        return false;
+    }
+}
+
+/**
+ * Build a public tracking URL for a tracking number that was entered manually
+ * (no EasyPost tracker). Falls back to a Google tracking search so the customer
+ * always gets a clickable link.
+ */
+export function fallbackTrackingUrl(carrier: string | undefined, trackingNumber: string): string {
+    const t = encodeURIComponent(trackingNumber);
+    switch ((carrier || '').toLowerCase()) {
+        case 'usps':
+            return `https://tools.usps.com/go/TrackConfirmAction?tLabels=${t}`;
+        case 'ups':
+            return `https://www.ups.com/track?tracknum=${t}`;
+        case 'fedex':
+            return `https://www.fedex.com/fedextrack/?trknbr=${t}`;
+        case 'dhl':
+        case 'dhlexpress':
+            return `https://www.dhl.com/us-en/home/tracking.html?tracking-id=${t}`;
+        default:
+            return `https://www.google.com/search?q=${t}+tracking`;
+    }
+}

--- a/src/types/Order.ts
+++ b/src/types/Order.ts
@@ -27,6 +27,24 @@ export interface OrderStatusUpdate {
     message?: string;
 }
 
+/**
+ * Shipment record for a fulfilled order. Populated when staff buy postage —
+ * either through the EasyPost/Pirate Ship integration (`src/lib/shipping.ts`)
+ * or by pasting a tracking number bought manually in Pirate Ship. EasyPost is
+ * what Pirate Ship runs on, so a label bought either way maps to these fields.
+ */
+export interface OrderShipment {
+    carrier?: string;          // e.g. "USPS", "UPS"
+    service?: string;          // e.g. "First", "Priority"
+    trackingNumber?: string;
+    trackingUrl?: string;      // public carrier/EasyPost tracking page
+    labelUrl?: string;         // postage label PDF/PNG (EasyPost-hosted)
+    easypostShipmentId?: string;
+    cost?: number;             // postage paid, USD (for the audit/stats trail)
+    estDeliveryDate?: string;  // ISO date string when known
+    shippedAt?: Date;
+}
+
 /** Which storefront an order came through. */
 export type OrderPathway = 'student' | 'guest';
 /** How the order was paid. */
@@ -55,6 +73,11 @@ export interface Order {
     stripePaymentIntentId?: string;
     shippingCountry?: string;
     shippingAddress?: ShippingAddress;
+    // Postage/tracking, set at fulfillment time (Pirate Ship / EasyPost).
+    shipment?: OrderShipment;
+    // Units reserved against inventory for this order (guest/Stripe path). The
+    // webhook commits these on payment or releases them if the session expires.
+    inventoryHold?: { variantId: string; quantity: number }[];
     checkoutData: Record<string, string | ShippingAddress>;
     status: 'pending' | 'approved' | 'fulfilled' | 'denied' | 'refunded';
     statusHistory: OrderStatusUpdate[];

--- a/src/types/Order.ts
+++ b/src/types/Order.ts
@@ -59,4 +59,7 @@ export interface Order {
     status: 'pending' | 'approved' | 'fulfilled' | 'denied' | 'refunded';
     statusHistory: OrderStatusUpdate[];
     createdAt: Date;
+    // When true, the order is a test/junk order: hidden from the default admin
+    // list and excluded from stats/revenue. Toggleable by admins.
+    isTest?: boolean;
 }


### PR DESCRIPTION
**Stacked PR 1 of 4** — base `store-v2`. Part of the shop upgrade program (`SHOP_UPGRADE_PROMPT.md`, lands in PR 4).

## What
Customer experience for both pathways, plus real postage/tracking.

- **Pirate Ship shipping via EasyPost** (`src/lib/shipping.ts`) — Pirate Ship runs on EasyPost, so this fetches rates, buys labels, and gets tracking through EasyPost. Config-gated (`EASYPOST_API_KEY`); with no key it falls back to staff pasting a tracking number bought manually in Pirate Ship.
- **Admin fulfillment** — `ShippingPanel` + `POST /api/admin/orders/[id]/shipping` buy a label or record manual tracking, flip the order to `fulfilled`, and email the customer the tracking link. `Order.shipment` field; tracking surfaced in the shipped email and on `/orders`.
- **Reorder** button on `/orders` (re-fetches live products so prices are correct per pathway).
- **Guest order lookup** by email + order id (`/orders/track` + `/api/orders/lookup`, rate-limited, enumeration-safe), linked from the confirmation email; thank-you page links to it.
- **Checkout polish** — mobile spacing, redirect spinner, error retry.
- **Student cart cross-device sync** to Redis (`/api/cart`); localStorage stays the guest fallback; clear-on-confirmed-success invariant preserved.
- Append-only **audit log** lib (used here by the shipping route).

## Invariants preserved
Server-side price re-verification, webhook-confirmed Stripe, fire-and-forget Airtable, clear-on-success-only cart — all intact.

## Verify
`tsc --noEmit`, `next build`, `next lint` all clean. New env vars documented in `.env.example`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)