### PR TITLE
Catalog: search, categories, sort, empty/loading states

### DIFF
--- a/docs/INVENTORY.md
+++ b/docs/INVENTORY.md
@@ -1,0 +1,103 @@
+# Inventory model
+
+How stock works in the Hack Club Shop, across Airtable, Redis, and the two
+checkout pathways. Read this before touching `src/lib/inventory.ts` or either
+checkout route.
+
+## The shape of the problem
+
+A variant can sell out, and we sell on two pathways at once:
+
+- **Student (points)** orders settle **instantly** — points are internal, there's
+  no external confirmation step. Stock can be decremented at order time.
+- **Guest (Stripe)** orders have an **in-flight window**: the order is created
+  `unpaid` when the Checkout Session is made, and only confirmed by the webhook
+  seconds-to-minutes later. During that window the units must be held so two
+  guests can't buy the last one, but they must be **released** if the session is
+  abandoned/expires.
+
+So stock is modelled as a base count plus an in-flight overlay.
+
+## Source of truth
+
+- **Airtable `Products` table is authoritative for the base stock number.** Staff
+  manage stock in the spreadsheet (per variant, inside `Variants JSON`, and as a
+  convenience `Total Stock` column). This is the number that means "how many we
+  physically have to sell".
+- **Redis is the operational store.** It caches the base stock for fast reads and
+  holds the live `reserved` overlay that Airtable never sees.
+
+Redis keys (per variant id):
+
+| Key | Meaning | Written by |
+|---|---|---|
+| `inventory:{variantId}` | `{ stock, syncedAt }` — cached base stock from Airtable/Redis product | sync, admin quick-adjust |
+| `inventory:{variantId}:reserved` | integer count of units held by in-flight Stripe sessions | reserve / release / commit |
+
+**Available to sell** = `max(0, stock − reserved)`.
+
+A variant with **no stock number set at all** (`stock === undefined`) is treated
+as **unlimited** — this preserves today's behaviour for every existing product
+until staff opt a variant into tracking by giving it a number.
+
+## Reservation lifecycle (guest / Stripe)
+
+```
+checkout/stripe POST   → reserve(variant, qty)      reserved += qty
+   │
+   ├─ payment completes → webhook checkout.session.completed
+   │                        → commit(variant, qty)  reserved -= qty ; stock -= qty
+   │
+   └─ session expires    → webhook checkout.session.expired
+                            → release(variant, qty) reserved -= qty
+```
+
+- `reserve` happens **after** price/availability validation but **before** the
+  Stripe session is created, and re-checks `available >= qty` so two simultaneous
+  checkouts can't both grab the last unit. If reservation fails, checkout is
+  rejected with a clear out-of-stock error and no Stripe session is made.
+- `commit` is idempotent-safe: the webhook already guards on
+  `paymentStatus === 'paid'`, so commit runs at most once per order.
+- `release` only runs while the order is still `unpaid` (the webhook already
+  checks this before marking the session expired/denied).
+- The reserved qty per order is stored on the order itself
+  (`order.inventoryHold`) so the webhook knows exactly what to commit/release
+  without recomputing from the cart.
+
+## Student / points orders
+
+Points orders settle in the same request, so there is no reservation window:
+they call `commit` directly (decrement available stock immediately) after points
+are validated and before the order is saved. If `available < qty`, the order is
+rejected before any points are deducted.
+
+## Conflict rule (reconciliation)
+
+Airtable is authoritative for the base number; Redis `reserved` is the in-flight
+overlay that Airtable doesn't model. The sync (`syncInventoryFromAirtable`) reads
+each variant's Airtable stock and overwrites the Redis `inventory:{variantId}`
+base **without touching `reserved`**. So:
+
+- Staff lowering stock in Airtable (e.g. after a manual count) wins on next sync.
+- In-flight reservations are preserved across a sync (they live in a separate
+  key), so a sync mid-checkout never double-frees a held unit.
+- When we `commit` a sale we decrement the cached base stock in Redis, which is
+  what gates further sales. Airtable is **not** decremented live — staff reconcile
+  the spreadsheet during their next count, and the next sync re-seeds Redis from
+  it. (`commitReserved` accepts an optional `mirror` callback if live write-back is
+  wired later; today none is passed, so Redis leads Airtable between counts.)
+
+Everything in `inventory.ts` is **fire-and-forget safe** like the email and
+Airtable-mirror layers: a Redis/Airtable hiccup degrades to "treat as available"
+rather than blocking a purchase, EXCEPT the explicit oversell check at checkout,
+which fails closed (rejects) only when it can positively prove `available < qty`.
+
+## Enabling stock tracking on a variant
+
+1. Give the variant a `stock` number (admin product form, or the
+   `/admin/inventory` quick-adjust, or the Airtable `Variants JSON`).
+2. Run a sync (the `/admin/inventory` "Sync from Airtable" button, or
+   `POST /api/admin/inventory/sync`).
+3. The storefront immediately reflects available stock and blocks oversells.
+
+Variants left without a number stay unlimited — no migration required.

--- a/src/app/admin/inventory/page.tsx
+++ b/src/app/admin/inventory/page.tsx
@@ -1,0 +1,246 @@
+'use client';
+
+import { useState, useEffect, useMemo } from 'react';
+import { useSession, signIn } from 'next-auth/react';
+import Link from 'next/link';
+import { motion } from 'framer-motion';
+
+interface Row {
+    productId: string;
+    productName: string;
+    variantId: string;
+    variantName: string;
+    size?: string;
+    color?: string;
+    stock: number | null;     // null = untracked/unlimited
+    reserved: number;
+    available: number | null;
+}
+
+const LOW_THRESHOLD = 5;
+
+export default function InventoryAdmin() {
+    const { data: session, status } = useSession();
+    const [rows, setRows] = useState<Row[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const [notice, setNotice] = useState<string | null>(null);
+    const [lowOnly, setLowOnly] = useState(false);
+    const [syncing, setSyncing] = useState(false);
+    const [savingId, setSavingId] = useState<string | null>(null);
+    const [edits, setEdits] = useState<Record<string, string>>({});
+
+    useEffect(() => {
+        if (status === 'unauthenticated') signIn('hackclub', { callbackUrl: '/admin/inventory' });
+    }, [status]);
+
+    const load = async () => {
+        try {
+            const res = await fetch('/api/admin/inventory');
+            if (!res.ok) {
+                setError(res.status === 403 ? 'You don’t have permission to manage inventory.' : 'Failed to load inventory');
+                return;
+            }
+            const data = await res.json();
+            setRows(data.rows || []);
+        } catch {
+            setError('Failed to load inventory');
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    useEffect(() => {
+        if (session) load();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [session]);
+
+    const sync = async () => {
+        setSyncing(true);
+        setError(null);
+        setNotice(null);
+        try {
+            const res = await fetch('/api/admin/inventory/sync', { method: 'POST' });
+            const data = await res.json();
+            if (!res.ok || data.ok === false) {
+                setError(data.error || 'Sync failed');
+            } else {
+                setNotice(`Synced ${data.synced} variant${data.synced === 1 ? '' : 's'} from Airtable.`);
+                await load();
+            }
+        } catch {
+            setError('Sync failed');
+        } finally {
+            setSyncing(false);
+        }
+    };
+
+    const saveStock = async (row: Row) => {
+        const raw = edits[row.variantId];
+        if (raw === undefined) return;
+        const trimmed = raw.trim();
+        const stock = trimmed === '' ? null : parseInt(trimmed, 10);
+        if (stock !== null && (Number.isNaN(stock) || stock < 0)) {
+            setError('Stock must be a non-negative number (or blank for unlimited).');
+            return;
+        }
+        setSavingId(row.variantId);
+        setError(null);
+        try {
+            const res = await fetch('/api/admin/inventory', {
+                method: 'PATCH',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ productId: row.productId, variantId: row.variantId, stock }),
+            });
+            const data = await res.json();
+            if (!res.ok) {
+                setError(data.error || 'Could not save');
+                return;
+            }
+            setRows(prev => prev.map(r =>
+                r.variantId === row.variantId
+                    ? { ...r, stock: data.stock, available: data.stock === null ? null : Math.max(0, data.stock - r.reserved) }
+                    : r,
+            ));
+            setEdits(prev => { const n = { ...prev }; delete n[row.variantId]; return n; });
+        } catch {
+            setError('Could not save');
+        } finally {
+            setSavingId(null);
+        }
+    };
+
+    const visible = useMemo(() => {
+        if (!lowOnly) return rows;
+        return rows.filter(r => r.available !== null && r.available <= LOW_THRESHOLD);
+    }, [rows, lowOnly]);
+
+    if (status === 'loading' || (session && loading)) {
+        return (
+            <div className="min-h-screen flex items-center justify-center bg-hackclub-smoke">
+                <div className="text-hackclub-dark font-bold">Loading…</div>
+            </div>
+        );
+    }
+    if (!session) return null;
+
+    return (
+        <div className="min-h-screen bg-white text-hackclub-dark"
+            style={{
+                backgroundImage: 'linear-gradient(to right, #e0f2fe 1px, transparent 1px), linear-gradient(to bottom, #e0f2fe 1px, transparent 1px)',
+                backgroundSize: '30px 30px',
+            }}
+        >
+            <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+                <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.4 }}>
+                    <Link href="/admin" className="text-hackclub-slate hover:text-hackclub-dark mb-2 inline-block font-medium">
+                        ← Back to Dashboard
+                    </Link>
+                    <div className="flex flex-wrap items-end justify-between gap-4 mb-2">
+                        <h1 className="text-5xl sm:text-6xl font-black text-hackclub-dark">Inventory</h1>
+                        <button
+                            type="button"
+                            onClick={sync}
+                            disabled={syncing}
+                            className="bg-hackclub-blue hover:bg-blue-600 text-white font-bold px-5 py-2.5 rounded-full transition-colors disabled:opacity-50"
+                        >
+                            {syncing ? 'Syncing…' : 'Sync from Airtable'}
+                        </button>
+                    </div>
+                    <p className="text-lg text-hackclub-slate font-medium mb-6">
+                        Stock is tracked per variant. Leave a stock field blank for unlimited. Airtable is the source of truth — edits here also update the product and re-sync to Airtable.
+                    </p>
+
+                    <div className="mb-6">
+                        <button
+                            type="button"
+                            onClick={() => setLowOnly(v => !v)}
+                            className={`inline-flex items-center gap-2 px-4 py-2 rounded-full text-sm font-bold border-2 transition-colors ${lowOnly ? 'bg-hackclub-orange text-white border-hackclub-orange' : 'bg-white text-hackclub-slate border-hackclub-smoke hover:border-hackclub-slate'}`}
+                            aria-pressed={lowOnly}
+                        >
+                            <span className={`w-2 h-2 rounded-full ${lowOnly ? 'bg-white' : 'bg-hackclub-muted'}`} />
+                            Low stock only (≤ {LOW_THRESHOLD})
+                        </button>
+                    </div>
+
+                    {error && (
+                        <div className="mb-4 p-4 bg-hackclub-red/10 border-2 border-hackclub-red rounded-xl">
+                            <p className="text-hackclub-red font-bold">{error}</p>
+                        </div>
+                    )}
+                    {notice && (
+                        <div className="mb-4 p-4 bg-hackclub-green/10 border-2 border-hackclub-green/40 rounded-xl">
+                            <p className="text-hackclub-green font-bold">{notice}</p>
+                        </div>
+                    )}
+
+                    <div className="bg-white rounded-2xl shadow-lg border-2 border-hackclub-smoke overflow-hidden">
+                        <div className="overflow-x-auto">
+                            <table className="w-full text-sm">
+                                <thead className="bg-hackclub-snow border-b-2 border-hackclub-smoke">
+                                    <tr className="text-left text-hackclub-muted font-black uppercase text-xs">
+                                        <th className="px-4 py-3">Product / Variant</th>
+                                        <th className="px-4 py-3 text-right">Stock</th>
+                                        <th className="px-4 py-3 text-right">Reserved</th>
+                                        <th className="px-4 py-3 text-right">Available</th>
+                                        <th className="px-4 py-3 text-right">Set stock</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {visible.length === 0 ? (
+                                        <tr><td colSpan={5} className="px-4 py-10 text-center text-hackclub-muted font-bold">No variants{lowOnly ? ' are low on stock' : ''}.</td></tr>
+                                    ) : visible.map(row => {
+                                        const untracked = row.stock === null;
+                                        const soldOut = row.available === 0;
+                                        const low = row.available !== null && row.available > 0 && row.available <= LOW_THRESHOLD;
+                                        return (
+                                            <tr key={row.variantId} className="border-b border-hackclub-smoke last:border-0">
+                                                <td className="px-4 py-3">
+                                                    <div className="font-bold text-hackclub-dark">{row.productName}</div>
+                                                    <div className="text-hackclub-muted">{row.variantName}{row.size ? ` · ${row.size}` : ''}{row.color ? ` · ${row.color}` : ''}</div>
+                                                </td>
+                                                <td className="px-4 py-3 text-right font-mono">{untracked ? <span className="text-hackclub-muted">∞</span> : row.stock}</td>
+                                                <td className="px-4 py-3 text-right font-mono">{row.reserved || 0}</td>
+                                                <td className="px-4 py-3 text-right font-mono">
+                                                    {untracked ? (
+                                                        <span className="text-hackclub-muted">∞</span>
+                                                    ) : soldOut ? (
+                                                        <span className="px-2 py-0.5 rounded-full text-xs font-black bg-hackclub-dark text-white">0</span>
+                                                    ) : low ? (
+                                                        <span className="px-2 py-0.5 rounded-full text-xs font-black bg-hackclub-orange text-white">{row.available}</span>
+                                                    ) : (
+                                                        <span className="text-hackclub-dark font-bold">{row.available}</span>
+                                                    )}
+                                                </td>
+                                                <td className="px-4 py-3">
+                                                    <div className="flex items-center justify-end gap-2">
+                                                        <input
+                                                            type="number"
+                                                            min={0}
+                                                            placeholder={untracked ? '∞' : String(row.stock)}
+                                                            value={edits[row.variantId] ?? ''}
+                                                            onChange={(e) => setEdits(prev => ({ ...prev, [row.variantId]: e.target.value }))}
+                                                            className="w-20 rounded-lg border-2 border-hackclub-smoke px-2 py-1 text-right font-mono focus:outline-none focus:border-hackclub-blue"
+                                                        />
+                                                        <button
+                                                            type="button"
+                                                            onClick={() => saveStock(row)}
+                                                            disabled={savingId === row.variantId || edits[row.variantId] === undefined}
+                                                            className="px-3 py-1.5 rounded-lg text-xs font-bold text-white bg-hackclub-green hover:bg-green-600 disabled:opacity-40"
+                                                        >
+                                                            {savingId === row.variantId ? '…' : 'Save'}
+                                                        </button>
+                                                    </div>
+                                                </td>
+                                            </tr>
+                                        );
+                                    })}
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </motion.div>
+            </div>
+        </div>
+    );
+}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -153,6 +153,23 @@ export default function AdminDashboard() {
                             </Link>
                         </motion.div>
 
+                        {/* Inventory */}
+                        <motion.div
+                            initial={{ opacity: 0, y: 20 }}
+                            animate={{ opacity: 1, y: 0 }}
+                            transition={{ delay: 0.15 }}
+                        >
+                            <Link href="/admin/inventory">
+                                <div className="bg-white rounded-2xl shadow-lg border-2 border-hackclub-smoke p-6 hover:shadow-xl hover:border-hackclub-cyan transition-all cursor-pointer group">
+                                    <div className="w-12 h-12 bg-hackclub-cyan/10 rounded-lg flex items-center justify-center mb-4 group-hover:bg-hackclub-cyan/20 transition-colors">
+                                        <Icon glyph="package" size={24} style={{ color: 'var(--hackclub-cyan, #5bc0de)' }} />
+                                    </div>
+                                    <h3 className="text-xl font-black text-hackclub-dark mb-2">Inventory</h3>
+                                    <p className="text-hackclub-slate text-sm">Track stock, sync from Airtable, fix oversells</p>
+                                </div>
+                            </Link>
+                        </motion.div>
+
                         {/* Coupons */}
                         <motion.div
                             initial={{ opacity: 0, y: 20 }}
@@ -217,6 +234,23 @@ export default function AdminDashboard() {
                                     </div>
                                     <h3 className="text-xl font-black text-hackclub-dark mb-2">Statistics</h3>
                                     <p className="text-hackclub-slate text-sm">View sales and order statistics</p>
+                                </div>
+                            </Link>
+                        </motion.div>
+
+                        {/* Audit Log */}
+                        <motion.div
+                            initial={{ opacity: 0, y: 20 }}
+                            animate={{ opacity: 1, y: 0 }}
+                            transition={{ delay: 0.55 }}
+                        >
+                            <Link href="/admin/audit">
+                                <div className="bg-white rounded-2xl shadow-lg border-2 border-hackclub-smoke p-6 hover:shadow-xl hover:border-hackclub-slate transition-all cursor-pointer group">
+                                    <div className="w-12 h-12 bg-hackclub-slate/10 rounded-lg flex items-center justify-center mb-4 group-hover:bg-hackclub-slate/20 transition-colors">
+                                        <Icon glyph="history" size={24} style={{ color: 'var(--hackclub-slate, #3c4858)' }} />
+                                    </div>
+                                    <h3 className="text-xl font-black text-hackclub-dark mb-2">Audit Log</h3>
+                                    <p className="text-hackclub-slate text-sm">Who did what — refunds, points, status, stock</p>
                                 </div>
                             </Link>
                         </motion.div>

--- a/src/app/api/admin/airtable-backfill/route.ts
+++ b/src/app/api/admin/airtable-backfill/route.ts
@@ -11,6 +11,7 @@ import {
     mirrorUser,
     mirrorCoupon,
 } from '../../../../lib/airtableMirror';
+import { setStock } from '../../../../lib/inventory';
 
 const redis = new Redis({
     url: process.env.UPSTASH_REDIS_REST_URL!,
@@ -41,16 +42,24 @@ export async function POST() {
     // ~4 req/sec throttle to stay under Airtable's 5/sec limit.
     const throttle = () => new Promise((r) => setTimeout(r, 250));
 
-    const counts = { products: 0, coupons: 0, users: 0, orders: 0, errors: 0 };
+    const counts = { products: 0, coupons: 0, users: 0, orders: 0, variantsStocked: 0, errors: 0 };
 
     try {
-        // Products
+        // Products — also seed the inventory cache from each variant's stock so
+        // tracking works immediately without waiting for the first Airtable sync.
         const productKeys = await redis.keys('product:*');
         for (const key of productKeys) {
             const product = await redis.get<Product>(key);
             if (product?.id) {
                 await mirrorProduct(product);
                 counts.products++;
+                for (const v of product.variants || []) {
+                    const variantId = String(v.variant_id || v.id);
+                    if (!variantId) continue;
+                    const stock = typeof v.stock === 'number' ? v.stock : null;
+                    await setStock(variantId, stock);
+                    if (stock !== null) counts.variantsStocked++;
+                }
                 await throttle();
             }
         }

--- a/src/app/api/admin/inventory/route.ts
+++ b/src/app/api/admin/inventory/route.ts
@@ -1,0 +1,107 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { Redis } from '@upstash/redis';
+import { authOptions } from '../../auth/[...nextauth]/route';
+import { requireAdminPermission } from '../../../../lib/adminAuth';
+import { Product } from '../../../../types/Admin';
+import { mirrorProduct } from '../../../../lib/airtableMirror';
+import { getVariantStocks, setStock } from '../../../../lib/inventory';
+import { recordAudit } from '../../../../lib/auditLog';
+
+const redis = new Redis({
+    url: process.env.UPSTASH_REDIS_REST_URL!,
+    token: process.env.UPSTASH_REDIS_REST_TOKEN!,
+});
+
+/**
+ * Admin inventory view + quick-adjust. Lists every variant across all products
+ * with its live stock / reserved / available, and lets staff set a variant's
+ * stock number directly (which updates both the product record and the inventory
+ * cache, then re-mirrors the product to Airtable so the spreadsheet matches).
+ */
+export async function GET() {
+    const session = await getServerSession(authOptions);
+    const can = await requireAdminPermission(session, 'canManageProducts');
+    if (!can.allowed) return NextResponse.json({ error: 'Unauthorized' }, { status: 403 });
+
+    const keys = await redis.keys('product:*');
+    const products: Product[] = [];
+    for (const key of keys) {
+        const p = await redis.get<Product>(key);
+        if (p) products.push(p);
+    }
+
+    const variantIds = products.flatMap(p =>
+        (p.variants || []).map(v => String(v.variant_id || v.id)),
+    );
+    const stocks = await getVariantStocks(variantIds);
+
+    const rows = products.flatMap(p =>
+        (p.variants || []).map(v => {
+            const variantId = String(v.variant_id || v.id);
+            const s = stocks[variantId];
+            return {
+                productId: p.id,
+                productName: p.name,
+                variantId,
+                variantName: v.name,
+                size: v.size,
+                color: v.color,
+                stock: s?.stock ?? null,      // null = untracked/unlimited
+                reserved: s?.reserved ?? 0,
+                available: s?.available ?? null,
+            };
+        }),
+    );
+
+    return NextResponse.json({ rows });
+}
+
+export async function PATCH(request: Request) {
+    const session = await getServerSession(authOptions);
+    const can = await requireAdminPermission(session, 'canManageProducts');
+    if (!can.allowed) return NextResponse.json({ error: 'Unauthorized' }, { status: 403 });
+
+    const { productId, variantId, stock } = (await request.json()) as {
+        productId?: string;
+        variantId?: string;
+        stock?: number | null;
+    };
+    if (!productId || !variantId) {
+        return NextResponse.json({ error: 'productId and variantId are required' }, { status: 400 });
+    }
+
+    const product = await redis.get<Product>(`product:${productId}`);
+    if (!product) return NextResponse.json({ error: 'Product not found' }, { status: 404 });
+
+    // Normalize: empty/negative/NaN → untracked (unlimited).
+    const next = stock === null || stock === undefined || Number.isNaN(stock) || stock < 0
+        ? undefined
+        : Math.floor(stock);
+
+    let matched = false;
+    product.variants = (product.variants || []).map(v => {
+        if (String(v.variant_id || v.id) === String(variantId)) {
+            matched = true;
+            return { ...v, stock: next };
+        }
+        return v;
+    });
+    if (!matched) return NextResponse.json({ error: 'Variant not found' }, { status: 404 });
+
+    product.updatedAt = new Date();
+    await redis.set(`product:${productId}`, product);
+    await setStock(variantId, next === undefined ? null : next);
+    void mirrorProduct(product);
+
+    void recordAudit({
+        action: 'inventory.adjust',
+        actorId: session?.user?.id || 'unknown',
+        actorEmail: session?.user?.email || undefined,
+        target: variantId,
+        summary: `Set stock for "${product.name}" variant ${variantId} to ${next === undefined ? 'unlimited' : next}`,
+        metadata: { productId, stock: next ?? null },
+    });
+
+    return NextResponse.json({ ok: true, stock: next ?? null });
+}

--- a/src/app/api/admin/inventory/sync/route.ts
+++ b/src/app/api/admin/inventory/sync/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '../../../auth/[...nextauth]/route';
+import { requireAdminPermission } from '../../../../../lib/adminAuth';
+import { syncInventoryFromAirtable, isInventorySyncConfigured } from '../../../../../lib/inventory';
+
+/**
+ * Pull variant stock from Airtable into the Redis inventory cache on demand.
+ * Bypasses the min-interval guard (force) since an admin explicitly asked.
+ */
+export async function POST() {
+    const session = await getServerSession(authOptions);
+    const can = await requireAdminPermission(session, 'canManageProducts');
+    if (!can.allowed) return NextResponse.json({ error: 'Unauthorized' }, { status: 403 });
+
+    if (!isInventorySyncConfigured()) {
+        return NextResponse.json({ ok: false, error: 'Airtable is not configured.' }, { status: 200 });
+    }
+
+    const result = await syncInventoryFromAirtable(true);
+    if (!result.ok) {
+        return NextResponse.json({ ok: false, error: result.reason || 'Sync failed' }, { status: 502 });
+    }
+    return NextResponse.json({ ok: true, synced: result.synced });
+}

--- a/src/app/api/checkout/stripe/route.ts
+++ b/src/app/api/checkout/stripe/route.ts
@@ -4,6 +4,7 @@ import { validateCartItems, getProductById } from '../../../../lib/productValida
 import { isStructuredAddress, validateAddress } from '../../../../lib/address';
 import { rateLimit, rateLimitResponse } from '../../../../lib/rateLimit';
 import { saveGuestOrder } from '../../../../lib/guestOrders';
+import { reserve, release, StockLine } from '../../../../lib/inventory';
 import { Order, ShippingAddress } from '../../../../types/Order';
 
 /**
@@ -67,6 +68,25 @@ export async function POST(request: Request) {
 
         const itemsCashTotal = validation.verifiedCashTotal!;
 
+        // Reserve stock before creating the Stripe session, so two guests can't
+        // both buy the last unit during the in-flight payment window. Untracked
+        // variants are unlimited and always succeed. The hold is released by the
+        // webhook on expiry, or committed to a sale on payment.
+        const holdLines: StockLine[] = validation.items!.map(i => ({ variantId: i.variantId, quantity: i.quantity }));
+        const reservation = await reserve(holdLines);
+        if (!reservation.ok) {
+            const oversold = validation.items!.find(i => i.variantId === reservation.variantId);
+            const name = oversold?.name || 'An item';
+            return NextResponse.json(
+                {
+                    error: reservation.available > 0
+                        ? `Only ${reservation.available} of ${name} left — please reduce the quantity.`
+                        : `${name} just sold out.`,
+                },
+                { status: 409 },
+            );
+        }
+
         // Resolve the verified USD shipping cost from the first item's product.
         let shippingCost = 0;
         const firstProduct = await getProductById(items[0].id);
@@ -81,6 +101,10 @@ export async function POST(request: Request) {
         const origin = request.headers.get('origin') || process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000';
 
         const orderId = `order_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+
+        // From here on, a failure must release the stock we just reserved so a
+        // crashed checkout doesn't leak held units.
+        try {
 
         // Stripe only accepts absolute http(s) image URLs; a relative path (e.g.
         // "/images/x.svg") makes session creation fail entirely. Pass images only
@@ -147,15 +171,21 @@ export async function POST(request: Request) {
             stripeSessionId: session.id,
             shippingCountry: country,
             shippingAddress,
+            inventoryHold: holdLines.filter(l => l.quantity > 0),
             checkoutData: checkoutData || {},
             status: 'pending',
             statusHistory: [{ status: 'pending', timestamp: now }],
             createdAt: now,
         };
 
-        await saveGuestOrder(order);
+            await saveGuestOrder(order);
 
-        return NextResponse.json({ url: session.url, sessionId: session.id, orderId });
+            return NextResponse.json({ url: session.url, sessionId: session.id, orderId });
+        } catch (inner) {
+            // Roll back the reservation — the session/order never came to be.
+            await release(holdLines);
+            throw inner;
+        }
     } catch (error) {
         console.error('[Stripe Checkout] Error:', error);
         return NextResponse.json({ error: 'Failed to start checkout' }, { status: 500 });

--- a/src/app/api/orders/route.ts
+++ b/src/app/api/orders/route.ts
@@ -8,6 +8,7 @@ import { rateLimit, rateLimitResponse } from '../../../lib/rateLimit';
 import { PointsTransaction } from '../../../types/Points';
 import { validateCSRFToken } from '../../../lib/csrf';
 import { validateCartItems } from '../../../lib/productValidation';
+import { commitImmediate, restock, StockLine } from '../../../lib/inventory';
 import { mirrorOrder, mirrorUser } from '../../../lib/airtableMirror';
 import { sendEmail, buildOrderConfirmation, buildAdminNewOrder } from '../../../lib/email';
 
@@ -58,6 +59,8 @@ export async function POST(request: Request) {
         return rateLimitResponse();
     }
 
+    // Stock decremented for this attempt; restocked if the order then fails to save.
+    let committedStock: StockLine[] | null = null;
     try {
         const { items, pointsRequired, shippingCountry, shippingPointsCost, checkoutData, csrfToken, idempotencyKey } = await request.json() as {
             items: { id: string; name: string; price: string; quantity: number; variant_id?: string | number }[];
@@ -132,6 +135,25 @@ export async function POST(request: Request) {
                 balance: pointsBalance
             }, { status: 400 });
         }
+
+        // Decrement stock immediately — points orders settle in-request, so there's
+        // no reservation window. Fails closed before any points are deducted; if
+        // anything below throws, we release the units so they aren't leaked.
+        const stockLines: StockLine[] = validation.items!.map(i => ({ variantId: i.variantId, quantity: i.quantity }));
+        const stockResult = await commitImmediate(stockLines);
+        if (!stockResult.ok) {
+            const oversold = validation.items!.find(i => i.variantId === stockResult.variantId);
+            const name = oversold?.name || 'An item';
+            return NextResponse.json(
+                {
+                    error: stockResult.available > 0
+                        ? `Only ${stockResult.available} of ${name} left — please reduce the quantity.`
+                        : `${name} just sold out.`,
+                },
+                { status: 409 },
+            );
+        }
+        committedStock = stockLines;
 
         // Extract + validate the structured shipping address (if present in checkoutData).
         let shippingAddress: ShippingAddress | undefined;
@@ -238,6 +260,9 @@ export async function POST(request: Request) {
         });
     } catch (error) {
         console.error('[Orders API] Error creating order:', error);
+        // If we'd already decremented stock for this attempt, give it back so a
+        // failed save doesn't strand units. restock() is best-effort/no-throw.
+        if (committedStock) void restock(committedStock);
         return NextResponse.json({ error: 'Failed to create order' }, { status: 500 });
     }
 }

--- a/src/app/api/products/[id]/route.ts
+++ b/src/app/api/products/[id]/route.ts
@@ -4,6 +4,7 @@ import { getServerSession } from 'next-auth';
 import { authOptions } from '../../auth/[...nextauth]/route';
 import { requireAdminPermission } from '../../../../lib/adminAuth';
 import { resolveDualPrice } from '../../../../lib/variantPricing';
+import { getVariantStocks } from '../../../../lib/inventory';
 
 const redis = new Redis({
     url: process.env.UPSTASH_REDIS_REST_URL!,
@@ -12,7 +13,7 @@ const redis = new Redis({
 
 export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
     const productId = params.id;
-    
+
     try {
         const product = await redis.get<any>(`product:${productId}`);
 
@@ -41,6 +42,13 @@ export async function GET(req: NextRequest, { params }: { params: { id: string }
                 },
             })),
         };
+
+        // Enrich variants with live availability (null = untracked/unlimited).
+        const stocks = await getVariantStocks(result.sync_variants.map((v: any) => v.variant_id));
+        result.sync_variants = result.sync_variants.map((v: any) => ({
+            ...v,
+            available: stocks[v.variant_id]?.available ?? null,
+        }));
 
         return NextResponse.json({ result });
     } catch (error) {

--- a/src/app/api/products/route.ts
+++ b/src/app/api/products/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { Redis } from '@upstash/redis';
 import { resolveDualPrice } from '../../../lib/variantPricing';
+import { getVariantStocks } from '../../../lib/inventory';
 
 const redis = new Redis({
     url: process.env.UPSTASH_REDIS_REST_URL!,
@@ -10,30 +11,43 @@ const redis = new Redis({
 export async function GET() {
   try {
     const keys = await redis.keys('product:*');
-    const products: any[] = [];
-
+    const rawProducts: any[] = [];
     for (const key of keys) {
         const product = await redis.get<any>(key);
-        if (product) {
-            products.push({
-                id: product.id,
-                name: product.name,
-                thumbnail_url: product.thumbnail_url,
-                sync_variants: (product.variants || []).map((variant: any, idx: number) => ({
-                    id: variant.id || `${product.id}_var_${idx}`,
-                    variant_id: variant.variant_id || `${product.id}_var_${idx}`,
-                    name: variant.name,
-                    retail_price: (variant.price ?? 0).toString(),
-                    ...resolveDualPrice(variant),
-                    size: variant.size || 'One Size',
-                    color: variant.color || 'Default',
-                    product: {
-                        image: variant.image_url || product.image_url || product.thumbnail_url,
-                    },
-                })),
-            });
-        }
+        if (product) rawProducts.push(product);
     }
+
+    // Enrich variants with live availability in one batched stock read. `available`
+    // is null for untracked variants (unlimited) and a number when stock is tracked.
+    const variantIds = rawProducts.flatMap((p: any) =>
+        (p.variants || []).map((v: any, idx: number) => v.variant_id || v.id || `${p.id}_var_${idx}`),
+    );
+    const stocks = await getVariantStocks(variantIds);
+
+    const products = rawProducts.map((product: any) => ({
+        id: product.id,
+        name: product.name,
+        thumbnail_url: product.thumbnail_url,
+        category: product.category || null,
+        createdAt: product.createdAt || null,
+        sync_variants: (product.variants || []).map((variant: any, idx: number) => {
+            const variantId = variant.variant_id || variant.id || `${product.id}_var_${idx}`;
+            const available = stocks[variantId]?.available ?? null;
+            return {
+                id: variant.id || `${product.id}_var_${idx}`,
+                variant_id: variantId,
+                name: variant.name,
+                retail_price: (variant.price ?? 0).toString(),
+                ...resolveDualPrice(variant),
+                size: variant.size || 'One Size',
+                color: variant.color || 'Default',
+                available, // null = unlimited; number = units left
+                product: {
+                    image: variant.image_url || product.image_url || product.thumbnail_url,
+                },
+            };
+        }),
+    }));
 
     return NextResponse.json({ code: 200, result: products });
   } catch (error) {

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -4,6 +4,7 @@ import { getStripe } from '../../../../lib/stripe';
 import { getGuestOrder, getGuestOrderBySession, updateGuestOrder } from '../../../../lib/guestOrders';
 import { mirrorOrder } from '../../../../lib/airtableMirror';
 import { sendEmail, buildOrderConfirmation, buildAdminNewOrder } from '../../../../lib/email';
+import { commitReserved, release } from '../../../../lib/inventory';
 
 /**
  * Stripe webhook — the ONLY trusted signal that a guest order was paid. The
@@ -50,8 +51,13 @@ export async function POST(request: Request) {
                     break;
                 }
 
-                // Idempotent: ignore if already finalized.
+                // Idempotent: ignore if already finalized (also guards commit).
                 if (order.paymentStatus === 'paid') break;
+
+                // Convert the held reservation into a sale (decrements base stock).
+                if (order.inventoryHold && order.inventoryHold.length > 0) {
+                    await commitReserved(order.inventoryHold);
+                }
 
                 const email = order.guestEmail || session.customer_details?.email || undefined;
                 const updated = await updateGuestOrder(order.id, {
@@ -78,6 +84,10 @@ export async function POST(request: Request) {
                 const session = event.data.object as Stripe.Checkout.Session;
                 const order = await getGuestOrderBySession(session.id);
                 if (order && order.paymentStatus === 'unpaid') {
+                    // Free the held units — the guest never paid.
+                    if (order.inventoryHold && order.inventoryHold.length > 0) {
+                        await release(order.inventoryHold);
+                    }
                     await updateGuestOrder(order.id, { status: 'denied' });
                 }
                 break;

--- a/src/app/shop/page.tsx
+++ b/src/app/shop/page.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import React, { useState, useEffect, useContext } from 'react';
+import React, { useState, useEffect, useContext, useMemo } from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
 import { motion } from 'framer-motion';
 import { CartContext } from '../../context/CartContext';
+import { CardSkeleton } from '../components/Skeleton';
 import { getCashPrice, getPointsPrice, getDisplayPrice, isAvailableOn } from '../../lib/paymentUtils';
 import { usePathway } from '../../lib/usePathway';
 
@@ -17,6 +18,7 @@ interface Variant {
     retail_price: string;
     price_cash?: number;
     price_points?: number;
+    available?: number | null; // null = unlimited; number = units left
     product: { image: string };
 }
 
@@ -24,8 +26,12 @@ interface Product {
     id: string | number;
     name: string;
     thumbnail_url: string;
+    category?: string | null;
+    createdAt?: string | null;
     sync_variants: Variant[];
 }
+
+type SortKey = 'featured' | 'price-asc' | 'price-desc' | 'newest' | 'name';
 
 const Shop = () => {
     const [products, setProducts] = useState<Product[]>([]);
@@ -40,14 +46,67 @@ const Shop = () => {
     const cartContext = useContext(CartContext);
     const { pathway, loading: pathwayLoading } = usePathway();
 
+    // Catalog controls.
+    const [query, setQuery] = useState('');
+    const [category, setCategory] = useState<string>('all');
+    const [sort, setSort] = useState<SortKey>('featured');
+
     // Strict path separation: while auth resolves, show everything; once
     // resolved, only show products with at least one variant the active
     // pathway can actually buy.
-    const visibleProducts = pathwayLoading
-        ? products
-        : products.filter((product) =>
-              (product.sync_variants || []).some((variant) => isAvailableOn(variant, pathway))
-          );
+    const pathwayProducts = useMemo(
+        () =>
+            pathwayLoading
+                ? products
+                : products.filter((product) =>
+                      (product.sync_variants || []).some((variant) => isAvailableOn(variant, pathway)),
+                  ),
+        [products, pathway, pathwayLoading],
+    );
+
+    // Distinct categories present in the pathway-visible catalog (for the chips).
+    const categories = useMemo(() => {
+        const set = new Set<string>();
+        for (const p of pathwayProducts) {
+            if (p.category && p.category.trim()) set.add(p.category.trim());
+        }
+        return Array.from(set).sort((a, b) => a.localeCompare(b));
+    }, [pathwayProducts]);
+
+    // The pathway-aware unit price used for sorting/searching.
+    const priceFor = (p: Product): number => {
+        const v = p.sync_variants?.[0];
+        if (!v) return 0;
+        return (pathway === 'student' ? getPointsPrice(v) : getCashPrice(v)) || 0;
+    };
+
+    // Search → category → sort, layered on top of the pathway filter.
+    const visibleProducts = useMemo(() => {
+        const q = query.trim().toLowerCase();
+        let list = pathwayProducts;
+        if (q) list = list.filter((p) => p.name.toLowerCase().includes(q) || (p.category || '').toLowerCase().includes(q));
+        if (category !== 'all') list = list.filter((p) => (p.category || '').trim() === category);
+
+        const sorted = [...list];
+        switch (sort) {
+            case 'price-asc':
+                sorted.sort((a, b) => priceFor(a) - priceFor(b));
+                break;
+            case 'price-desc':
+                sorted.sort((a, b) => priceFor(b) - priceFor(a));
+                break;
+            case 'name':
+                sorted.sort((a, b) => a.name.localeCompare(b.name));
+                break;
+            case 'newest':
+                sorted.sort((a, b) => new Date(b.createdAt || 0).getTime() - new Date(a.createdAt || 0).getTime());
+                break;
+            default:
+                break; // 'featured' = catalog order
+        }
+        return sorted;
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [pathwayProducts, query, category, sort, pathway]);
 
     useEffect(() => {
         const fetchProducts = async () => {
@@ -113,7 +172,7 @@ const Shop = () => {
                     upEvent.clientY >= rect.top - 100 &&
                     upEvent.clientY <= rect.bottom + 100;
 
-                if (isNearCart && product.sync_variants && product.sync_variants.length > 0 && isAvailableOn(product.sync_variants[0], pathway) && cartContext) {
+                if (isNearCart && product.sync_variants && product.sync_variants.length > 0 && isAvailableOn(product.sync_variants[0], pathway) && product.sync_variants[0].available !== 0 && cartContext) {
                     droppedOnCart = true;
                     const variant = product.sync_variants[0];
 
@@ -145,11 +204,11 @@ const Shop = () => {
     };
 
     return (
-        <motion.div 
+        <motion.div
             initial={{ opacity: 0 }}
-            animate={{ opacity: loading ? 0 : 1 }}
+            animate={{ opacity: 1 }}
             transition={{ duration: 0.3 }}
-            className="min-h-screen bg-white" 
+            className="min-h-screen bg-white"
             style={{
                 backgroundImage: `
                   linear-gradient(to right, #e0f2fe 1px, transparent 1px),
@@ -160,7 +219,7 @@ const Shop = () => {
         >
             
             <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
-                <div className="mb-12">
+                <div className="mb-8">
                     <h1 className="text-5xl sm:text-6xl font-black text-hackclub-dark mb-4">
                         Browse Merch
                     </h1>
@@ -168,17 +227,87 @@ const Shop = () => {
                         Stickers, shirts, and more cool stuff
                     </p>
                 </div>
-                
+
+                {/* Search + sort */}
+                <div className="flex flex-col sm:flex-row gap-3 mb-5">
+                    <div className="relative flex-1">
+                        <svg className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-hackclub-muted pointer-events-none" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+                        </svg>
+                        <input
+                            type="search"
+                            value={query}
+                            onChange={(e) => setQuery(e.target.value)}
+                            placeholder="Search merch…"
+                            aria-label="Search products"
+                            className="w-full pl-11 pr-4 py-3 rounded-full border-2 border-hackclub-smoke bg-white text-hackclub-dark font-medium focus:outline-none focus:border-hackclub-red transition-colors"
+                        />
+                    </div>
+                    <label className="sr-only" htmlFor="sort">Sort products</label>
+                    <select
+                        id="sort"
+                        value={sort}
+                        onChange={(e) => setSort(e.target.value as SortKey)}
+                        className="px-4 py-3 rounded-full border-2 border-hackclub-smoke bg-white text-hackclub-dark font-bold focus:outline-none focus:border-hackclub-red transition-colors"
+                    >
+                        <option value="featured">Featured</option>
+                        <option value="price-asc">Price: low to high</option>
+                        <option value="price-desc">Price: high to low</option>
+                        <option value="newest">Newest</option>
+                        <option value="name">Name (A–Z)</option>
+                    </select>
+                </div>
+
+                {/* Category chips */}
+                {categories.length > 0 && (
+                    <div className="flex flex-wrap gap-2 mb-10">
+                        <CategoryChip label="All" active={category === 'all'} onClick={() => setCategory('all')} />
+                        {categories.map((c) => (
+                            <CategoryChip key={c} label={c} active={category === c} onClick={() => setCategory(c)} />
+                        ))}
+                    </div>
+                )}
+
                 {error && (
                     <div className="text-center py-20">
                         <p className="text-hackclub-red text-lg font-bold">⚠️ {error}</p>
                     </div>
                 )}
 
+                {loading ? (
+                    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+                        {Array.from({ length: 8 }).map((_, i) => <CardSkeleton key={i} />)}
+                    </div>
+                ) : !error && visibleProducts.length === 0 ? (
+                    <div className="text-center py-20">
+                        <div className="w-16 h-16 bg-hackclub-smoke rounded-full flex items-center justify-center mx-auto mb-4">
+                            <svg className="w-8 h-8 text-hackclub-muted" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M16 11V7a4 4 0 00-8 0v4M5 9h14l1 12H4L5 9z" />
+                            </svg>
+                        </div>
+                        <p className="text-hackclub-dark font-black text-lg">
+                            {query || category !== 'all' ? 'No merch matches that' : 'No merch yet'}
+                        </p>
+                        <p className="text-hackclub-slate font-medium mt-1">
+                            {query || category !== 'all' ? 'Try a different search or category.' : 'Check back soon!'}
+                        </p>
+                        {(query || category !== 'all') && (
+                            <button
+                                type="button"
+                                onClick={() => { setQuery(''); setCategory('all'); }}
+                                className="mt-5 inline-block bg-hackclub-red hover:bg-hackclub-orange text-white font-bold px-6 py-2.5 rounded-full transition-colors"
+                            >
+                                Clear filters
+                            </button>
+                        )}
+                    </div>
+                ) : (
                 <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
                     {visibleProducts.map((product) => {
                       const firstVariant = product.sync_variants?.[0];
-                      const canBuy = firstVariant ? isAvailableOn(firstVariant, pathway) : false;
+                      const soldOut = firstVariant?.available === 0;
+                      const lowStock = typeof firstVariant?.available === 'number' && firstVariant.available > 0 && firstVariant.available <= 5;
+                      const canBuy = firstVariant ? isAvailableOn(firstVariant, pathway) && !soldOut : false;
                       return (
                         <motion.div
                             key={product.id}
@@ -197,9 +326,19 @@ const Shop = () => {
                                     src={product.thumbnail_url}
                                     alt={product.name}
                                     fill
-                                    className="object-contain p-6 group-hover:scale-105 transition-transform duration-300 pointer-events-none"
+                                    className={`object-contain p-6 group-hover:scale-105 transition-transform duration-300 pointer-events-none ${soldOut ? 'opacity-40 grayscale' : ''}`}
                                     draggable={false}
                                 />
+                                {soldOut && (
+                                    <span className="absolute top-3 left-3 px-2.5 py-1 rounded-full text-xs font-black bg-hackclub-dark text-white">
+                                        Sold out
+                                    </span>
+                                )}
+                                {!soldOut && lowStock && (
+                                    <span className="absolute top-3 left-3 px-2.5 py-1 rounded-full text-xs font-black bg-hackclub-orange text-white">
+                                        Only {firstVariant!.available} left
+                                    </span>
+                                )}
                             </div>
                             <div className="flex flex-col gap-2 p-5 bg-white">
                                 <Link href={`/products/${product.id}`} className="block">
@@ -250,7 +389,7 @@ const Shop = () => {
                                              e.currentTarget.blur();
                                          }}
                                     >
-                                        {canBuy ? 'Add to Cart' : 'Not available'}
+                                        {canBuy ? 'Add to Cart' : soldOut ? 'Sold out' : 'Not available'}
                                     </button>
                                 </div>
                             </div>
@@ -258,6 +397,7 @@ const Shop = () => {
                       );
                     })}
                 </div>
+                )}
 
                 {draggingProduct && (
                     <motion.div
@@ -291,5 +431,22 @@ const Shop = () => {
         </motion.div>
     );
 };
+
+function CategoryChip({ label, active, onClick }: { label: string; active: boolean; onClick: () => void }) {
+    return (
+        <button
+            type="button"
+            onClick={onClick}
+            aria-pressed={active}
+            className={`px-4 py-1.5 rounded-full text-sm font-bold border-2 transition-colors ${
+                active
+                    ? 'bg-hackclub-red text-white border-hackclub-red'
+                    : 'bg-white text-hackclub-slate border-hackclub-smoke hover:border-hackclub-red hover:text-hackclub-red'
+            }`}
+        >
+            {label}
+        </button>
+    );
+}
 
 export default Shop;

--- a/src/lib/inventory.ts
+++ b/src/lib/inventory.ts
@@ -1,0 +1,291 @@
+/**
+ * Inventory: stock tracking + reservation across both checkout pathways.
+ *
+ * Read `docs/INVENTORY.md` first — it explains the model. In short:
+ *   - Airtable `Products` is authoritative for the base stock number.
+ *   - Redis caches that base (`inventory:{variantId}`) and holds the live
+ *     `reserved` overlay (`inventory:{variantId}:reserved`) that Airtable never
+ *     sees.
+ *   - available = max(0, stock - reserved).
+ *   - A variant with NO stock number set is unlimited (preserves legacy behaviour).
+ *
+ * Everything here is fire-and-forget safe like `email.ts`/`airtableMirror.ts`:
+ * a Redis/Airtable hiccup degrades to "treat as available" rather than blocking a
+ * purchase. The ONE exception is `reserve()`/`commitImmediate()`, which fail
+ * CLOSED — they reject only when they can positively prove available < qty.
+ */
+
+import { Redis } from '@upstash/redis';
+
+const redis = new Redis({
+    url: process.env.UPSTASH_REDIS_REST_URL!,
+    token: process.env.UPSTASH_REDIS_REST_TOKEN!,
+});
+
+const stockKey = (variantId: string) => `inventory:${variantId}`;
+const reservedKey = (variantId: string) => `inventory:${variantId}:reserved`;
+
+/** A unit a checkout wants to hold/sell. */
+export interface StockLine {
+    variantId: string;
+    quantity: number;
+}
+
+interface StockCache {
+    stock: number;
+    syncedAt: string;
+}
+
+/**
+ * Current snapshot for a variant. `stock === null` means "untracked / unlimited".
+ */
+export interface VariantStock {
+    variantId: string;
+    stock: number | null;
+    reserved: number;
+    available: number | null; // null when untracked (unlimited)
+}
+
+async function readStock(variantId: string): Promise<number | null> {
+    try {
+        const cached = await redis.get<StockCache>(stockKey(variantId));
+        if (cached && typeof cached.stock === 'number') return cached.stock;
+        return null;
+    } catch {
+        return null;
+    }
+}
+
+async function readReserved(variantId: string): Promise<number> {
+    try {
+        const r = await redis.get<number>(reservedKey(variantId));
+        return typeof r === 'number' && r > 0 ? r : 0;
+    } catch {
+        return 0;
+    }
+}
+
+/** Snapshot of a single variant's stock/reserved/available. */
+export async function getVariantStock(variantId: string): Promise<VariantStock> {
+    const [stock, reserved] = await Promise.all([readStock(variantId), readReserved(variantId)]);
+    const available = stock === null ? null : Math.max(0, stock - reserved);
+    return { variantId, stock, reserved, available };
+}
+
+/** Snapshot for many variants at once (admin views, storefront enrichment). */
+export async function getVariantStocks(variantIds: string[]): Promise<Record<string, VariantStock>> {
+    const unique = Array.from(new Set(variantIds.filter(Boolean)));
+    const entries = await Promise.all(unique.map(getVariantStock));
+    const out: Record<string, VariantStock> = {};
+    for (const e of entries) out[e.variantId] = e;
+    return out;
+}
+
+/** Set/seed the cached base stock for a variant. Used by sync + admin adjust. */
+export async function setStock(variantId: string, stock: number | null): Promise<void> {
+    try {
+        if (stock === null || Number.isNaN(stock)) {
+            await redis.del(stockKey(variantId));
+            return;
+        }
+        const cache: StockCache = { stock: Math.max(0, Math.floor(stock)), syncedAt: new Date().toISOString() };
+        await redis.set(stockKey(variantId), cache);
+    } catch (err) {
+        console.error('[inventory] setStock failed:', err instanceof Error ? err.message : err);
+    }
+}
+
+/**
+ * Atomically try to reserve units for every line. Fails CLOSED: if any tracked
+ * line can't be satisfied, all reservations made in this call are rolled back and
+ * the conflicting line is returned. Untracked variants (no stock number) always
+ * succeed. Returns { ok: true } or { ok: false, variantId, available }.
+ *
+ * Race-safety: we incrby reserved first (atomic), then re-read stock and verify
+ * reserved <= stock. If we overshot, we decrby back. This is the standard
+ * optimistic-reserve pattern and is correct without Lua because incrby is atomic.
+ */
+export async function reserve(lines: StockLine[]): Promise<
+    { ok: true } | { ok: false; variantId: string; available: number }
+> {
+    const applied: StockLine[] = [];
+    for (const line of lines) {
+        if (line.quantity <= 0) continue;
+        const stock = await readStock(line.variantId);
+        if (stock === null) continue; // untracked → unlimited
+
+        let newReserved: number;
+        try {
+            newReserved = await redis.incrby(reservedKey(line.variantId), line.quantity);
+        } catch (err) {
+            // Can't reserve safely → fail closed for this tracked line.
+            console.error('[inventory] reserve incrby failed:', err instanceof Error ? err.message : err);
+            await rollback(applied);
+            return { ok: false, variantId: line.variantId, available: 0 };
+        }
+
+        if (newReserved > stock) {
+            // Oversold — undo this line and everything before it.
+            await safeDecr(line.variantId, line.quantity);
+            await rollback(applied);
+            const available = Math.max(0, stock - (newReserved - line.quantity));
+            return { ok: false, variantId: line.variantId, available };
+        }
+        applied.push(line);
+    }
+    return { ok: true };
+}
+
+/** Release a held reservation (Stripe session expired/cancelled). Best-effort. */
+export async function release(lines: StockLine[]): Promise<void> {
+    await rollback(lines);
+}
+
+/**
+ * Convert a held reservation into a sale: drop the reservation AND decrement the
+ * cached base stock. Best-effort; also writes the new number back to Airtable so
+ * the spreadsheet stays roughly current. Used by the Stripe webhook on payment.
+ */
+export async function commitReserved(lines: StockLine[], mirror?: (variantId: string, stock: number) => void): Promise<void> {
+    for (const line of lines) {
+        if (line.quantity <= 0) continue;
+        await safeDecr(line.variantId, line.quantity);
+        const stock = await readStock(line.variantId);
+        if (stock === null) continue;
+        const next = Math.max(0, stock - line.quantity);
+        await setStock(line.variantId, next);
+        if (mirror) mirror(line.variantId, next);
+    }
+}
+
+/**
+ * Decrement available stock immediately, with no reservation window. Used by the
+ * student/points path (settles in-request). Fails CLOSED: returns the conflicting
+ * line if a tracked variant lacks availability, decrementing nothing.
+ */
+export async function commitImmediate(
+    lines: StockLine[],
+    mirror?: (variantId: string, stock: number) => void,
+): Promise<{ ok: true } | { ok: false; variantId: string; available: number }> {
+    // First reserve (which does the atomic oversell check)…
+    const reserved = await reserve(lines);
+    if (!reserved.ok) return reserved;
+    // …then immediately commit those reservations into sold stock.
+    await commitReserved(lines, mirror);
+    return { ok: true };
+}
+
+/**
+ * Add units back to base stock — the inverse of a committed sale. Used to undo a
+ * `commitImmediate` when the order fails to save (student path), and available for
+ * admin refunds that should restore stock. Best-effort; untracked variants are
+ * left untouched.
+ */
+export async function restock(lines: StockLine[]): Promise<void> {
+    for (const line of lines) {
+        if (line.quantity <= 0) continue;
+        const stock = await readStock(line.variantId);
+        if (stock === null) continue; // untracked → nothing to restore
+        await setStock(line.variantId, stock + line.quantity);
+    }
+}
+
+async function rollback(lines: StockLine[]): Promise<void> {
+    for (const line of lines) {
+        if (line.quantity > 0) await safeDecr(line.variantId, line.quantity);
+    }
+}
+
+async function safeDecr(variantId: string, qty: number): Promise<void> {
+    try {
+        const next = await redis.decrby(reservedKey(variantId), qty);
+        // Never let reserved drift negative (e.g. double-release).
+        if (next < 0) await redis.set(reservedKey(variantId), 0);
+    } catch (err) {
+        console.error('[inventory] decr failed:', err instanceof Error ? err.message : err);
+    }
+}
+
+// ── Airtable read-sync (the new read direction) ──────────────────────────────
+//
+// Reads each product's variant stock from the Airtable Products table and seeds
+// the Redis base stock cache, WITHOUT touching the `reserved` overlay (see the
+// conflict rule in docs/INVENTORY.md). Cached behind a short TTL guard so the
+// storefront never hammers Airtable.
+
+const AIRTABLE_API_KEY = process.env.AIRTABLE_API_KEY;
+const AIRTABLE_BASE_ID = process.env.AIRTABLE_BASE_ID;
+const PRODUCTS_TABLE = process.env.AIRTABLE_PRODUCTS_TABLE || 'Products';
+const SYNC_GUARD_KEY = 'inventory:lastSync';
+const SYNC_MIN_INTERVAL_MS = 60_000; // don't re-sync Airtable more than once a minute
+
+export const isInventorySyncConfigured = () => Boolean(AIRTABLE_API_KEY && AIRTABLE_BASE_ID);
+
+interface AirtableVariant {
+    variant_id?: string;
+    id?: string;
+    stock?: number | string;
+}
+
+interface SyncResult {
+    ok: boolean;
+    synced: number;       // variants whose stock was seeded
+    skipped?: boolean;    // true if guarded by the min-interval
+    reason?: string;
+}
+
+/**
+ * Pull variant stock from Airtable → Redis base cache. `force` bypasses the
+ * min-interval guard (used by the admin "Sync now" button). Never throws.
+ */
+export async function syncInventoryFromAirtable(force = false): Promise<SyncResult> {
+    if (!isInventorySyncConfigured()) return { ok: false, synced: 0, reason: 'not_configured' };
+
+    try {
+        if (!force) {
+            const last = await redis.get<number>(SYNC_GUARD_KEY);
+            if (last && Date.now() - last < SYNC_MIN_INTERVAL_MS) {
+                return { ok: true, synced: 0, skipped: true };
+            }
+        }
+
+        let synced = 0;
+        let offset: string | undefined;
+        do {
+            const url = new URL(`https://api.airtable.com/v0/${AIRTABLE_BASE_ID}/${encodeURIComponent(PRODUCTS_TABLE)}`);
+            if (offset) url.searchParams.set('offset', offset);
+            const res = await fetch(url.toString(), {
+                headers: { Authorization: `Bearer ${AIRTABLE_API_KEY}` },
+            });
+            if (!res.ok) {
+                return { ok: false, synced, reason: `Airtable ${res.status}` };
+            }
+            const data = (await res.json()) as { records?: { fields?: Record<string, unknown> }[]; offset?: string };
+
+            for (const record of data.records || []) {
+                const raw = record.fields?.['Variants JSON'];
+                if (typeof raw !== 'string') continue;
+                let variants: AirtableVariant[];
+                try {
+                    variants = JSON.parse(raw);
+                } catch {
+                    continue;
+                }
+                for (const v of variants) {
+                    const vid = v.variant_id || v.id;
+                    if (!vid) continue;
+                    const stock = v.stock === undefined || v.stock === null || v.stock === '' ? null : Number(v.stock);
+                    await setStock(vid, stock === null || Number.isNaN(stock) ? null : stock);
+                    if (stock !== null && !Number.isNaN(stock)) synced++;
+                }
+            }
+            offset = data.offset;
+        } while (offset);
+
+        await redis.set(SYNC_GUARD_KEY, Date.now());
+        return { ok: true, synced };
+    } catch (err) {
+        console.error('[inventory] sync failed:', err instanceof Error ? err.message : err);
+        return { ok: false, synced: 0, reason: err instanceof Error ? err.message : 'sync failed' };
+    }
+}

--- a/src/lib/productValidation.ts
+++ b/src/lib/productValidation.ts
@@ -69,6 +69,7 @@ export interface VerifiedCartItem {
     pricePoints?: number;   // verified per-unit points price (student path)
     quantity: number;
     thumbnail_url?: string;
+    variantId: string;      // canonical variant id, for stock reservation
 }
 
 /**
@@ -141,6 +142,7 @@ export async function validateCartItems(items: CartItemForValidation[]): Promise
             pricePoints: price_points,
             quantity: item.quantity,
             thumbnail_url: variant.image_url || product.image_url || product.thumbnail_url,
+            variantId: String(variant.variant_id || variant.id),
         });
     }
 

--- a/src/types/Product.tsx
+++ b/src/types/Product.tsx
@@ -7,6 +7,7 @@ export interface Variant {
     // price_cash (USD) → adult/Stripe path; price_points → student path.
     price_cash?: number;
     price_points?: number;
+    available?: number | null; // null = unlimited; number = units left
     size: string;
     color: string;
     product: {


### PR DESCRIPTION
**Stacked PR 3 of 4** — base `track2-inventory` (#9). Review/merge after PR 2.

## What
`/shop` discoverability, layered on top of the existing pathway filter so it stays correct for both student and guest.

- **Search** by product name + category.
- **Category chips** driven by the real `Product.category` (already managed in the admin product form — no admin changes needed).
- **Sort**: featured / price asc·desc (pathway-aware) / newest / name.
- **CardSkeleton** grid during the initial fetch (previously the page was `opacity-0` until loaded).
- **Friendly empty state** with a Clear-filters action, distinct from the empty-catalog state.

Single-file change (`src/app/shop/page.tsx`) plus it consumes `category`/`createdAt` already exposed by the products API in PR 2.

## Verify
`tsc`, `build`, `lint` clean on this branch tip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)