### PR TITLE
Admin power: order search/CSV, audit log, richer stats

### DIFF
--- a/SHOP_UPGRADE_PROMPT.md
+++ b/SHOP_UPGRADE_PROMPT.md
@@ -1,0 +1,261 @@
+# Hack Club Shop — Upgrade & Improvement Spec
+
+> A grounded, end-to-end improvement prompt for the Hack Club Shop. Written against the
+> actual codebase (Next.js 13 App Router · TypeScript · Tailwind · Upstash Redis · Stripe ·
+> NextAuth/Hack Club OAuth · Airtable mirror · Vercel Blob). Scope spans **admin**,
+> **catalog**, **inventory (Airtable-backed)**, and **customer experience** for both the
+> **adult/guest (Stripe)** and **hack-clubber/student (points)** pathways.
+
+---
+
+## 0. Context the implementer must hold
+
+The shop forks into two pathways purely off auth state (`src/lib/usePathway.ts`):
+
+- **`student`** — logged in via Hack Club OAuth, pays in **points**, orders go through
+  `POST /api/orders` (immediate points deduction, order created `pending`→`approved`).
+- **`guest`** — logged out, pays **real USD** via **Stripe Checkout**, order created
+  `unpaid` and only confirmed by the `checkout.session.completed` webhook (the success
+  redirect is never trusted as proof of payment).
+
+Data lives in **Upstash Redis** as the source of truth. **Airtable is a fire-and-forget,
+write-only mirror** (`src/lib/airtableMirror.ts`) for staff visibility — the app does *not*
+currently read catalog/inventory back from it (only Projects reads from Airtable).
+
+Dual pricing per variant (`src/types/Admin.ts`): a variant is buyable on a pathway **iff**
+its price for that pathway is set — `price_cash` (USD) → guest, `price_points` → student.
+
+**Non-negotiable invariants** (do not regress these):
+1. **All prices are re-verified server-side** against Redis on every checkout. Client prices
+   are never trusted.
+2. **Stripe is webhook-confirmed only.** Never mark a guest order paid from the redirect.
+3. **Airtable failures must never break a purchase** — keep all mirror calls fire-and-forget/no-throw.
+4. **Idempotency + rate limits** on order creation stay intact.
+5. **Cart clears only on confirmed success**, never on a cancelled/abandoned payment.
+6. **Permission gates** (`AdminPermissions` in `src/types/Admin.ts`) are enforced on both the
+   page and the API route for every admin action.
+
+---
+
+## 1. Goals (what "really good" means here)
+
+Ship a cohesive set of upgrades across four tracks. Each item below is independently
+shippable — prefer small, verifiable PRs over one mega-change. Preserve the Hack Club
+visual identity (Phantom Sans, the brand palette, draggable-sticker playfulness) while
+raising polish, accessibility, and operational power.
+
+---
+
+## 2. INVENTORY — Airtable-backed stock (highest-leverage new capability)
+
+Today `ProductVariant.stock` is captured in the admin form, stored in Redis, and **never
+enforced or surfaced**. Make inventory real, with **Airtable as the system of record for
+stock levels** so non-engineer staff can manage it in a spreadsheet.
+
+**Design:**
+- Introduce an inventory sync that **reads** stock from the Airtable `Products`/variants
+  table into Redis on a cadence (cron/route) and on-demand, caching in Redis
+  (`inventory:{variantId}` with a short TTL) so the storefront stays fast and Airtable
+  rate limits aren't hit on every page load. This is a *new* read direction — build it
+  alongside the existing write-only mirror, don't break the mirror.
+- Decide and document the **conflict rule**: Airtable is authoritative for stock; the app
+  decrements a Redis "reserved/sold" counter on order, and the sync reconciles. Write this
+  rule down in `docs/`.
+- **Enforce stock at checkout** in BOTH paths:
+  - `POST /api/orders` (student) and `POST /api/checkout/stripe` (guest) must re-check
+    available stock server-side and reject oversells with a clear 409-style error.
+  - For Stripe, decrement reserved stock when the session is created and **release the
+    reservation if the session expires/cancels** (handle `checkout.session.expired`).
+    Only convert reserved→sold on `checkout.session.completed`.
+- **Surface stock in the UI**: "Only N left", "Out of stock" (disable Add to Cart),
+  low-stock badges on `ProductCard` and the product detail page. Respect pathway — a
+  variant with no price for the current pathway is already hidden; stock is an additional gate.
+- **Admin inventory view**: a `/admin/inventory` page (gated by `canManageProducts`) showing
+  every variant, current stock, reserved, sold, and a low-stock filter. Link out to the
+  Airtable row for editing, plus an in-app quick-adjust that writes back through the mirror.
+- **Backfill/repair**: extend or add to `/api/admin/airtable-backfill` so stock can be
+  initialized from current Redis state without data loss.
+
+**Acceptance:** A variant set to stock 0 in Airtable cannot be purchased on either pathway;
+an abandoned Stripe session releases its reservation; the admin inventory page reflects
+reality within one sync cycle.
+
+---
+
+## 3. CATALOG — discoverability & merchandising
+
+The `category` field exists on `Product` but is unused; there is **no search, filter, sort,
+or empty state** on `/shop`.
+
+- **Search** (client-side over the fetched catalog is fine to start): name + description match.
+- **Categories**: make `category` real — filter chips/tabs on `/shop`, category management in
+  the admin product form. Backfill existing products to a default category.
+- **Sort**: price (pathway-aware), newest, name.
+- **Empty & loading states**: use the existing `Skeleton`/`CardSkeleton` for the initial
+  product fetch (today the grid renders empty while loading), and a friendly empty state
+  when filters match nothing.
+- **Product detail upgrades**: image gallery (multiple images per product/variant), variant
+  selection that previews the matching image, richer description (markdown?), related/"more
+  from this category" rail.
+- **Variant selector polish**: replace the bare `<select>` with an accessible, on-brand
+  control; show color swatches and size pills instead of dropdown text where applicable.
+- **Featured / new / sold-out** merchandising flags controllable from admin.
+
+**Acceptance:** A shopper can search "sticker", filter to a category, sort by price, and see
+correct pathway-aware prices and stock — on mobile and desktop.
+
+---
+
+## 4. ADMIN — operational power
+
+Build on the existing dashboard, orders, products, users, coupons, admins, stats, projects.
+
+- **Orders**: search/filter (by status, pathway, email/user, date range), pagination,
+  CSV export, and a fulfillment workflow that captures **tracking number + carrier** and
+  includes it in the "shipped" status email. Bulk actions (approve/fulfill multiple).
+- **Stats**: richer analytics — revenue over time (chart), points spent vs. cash revenue
+  split, conversion (carts → orders), top products already exists; add low-stock alerts and
+  abandoned/expired Stripe sessions. Keep test orders excluded.
+- **Products**: category + merchandising flags (see §3), bulk price edit, duplicate-product
+  action, and inline image management for the new gallery.
+- **Inventory**: the `/admin/inventory` page from §2.
+- **Audit log**: record who did what (refunds, point grants, status changes) — a Redis
+  append log surfaced in admin, since these are real money/points actions.
+- **Coupons**: usage analytics (how many redeemed, revenue impact) and per-pathway coupon
+  applicability if not already supported.
+
+**Acceptance:** A store manager can find an order by customer email, mark it shipped with a
+tracking number (customer gets an email with the link), and export the month's orders to CSV.
+
+---
+
+## 5. CUSTOMER EXPERIENCE — both pathways
+
+- **Accessibility pass (do this early, it's currently weak)**: ARIA labels on icon buttons
+  (cart, user, menu), `sr-only` text, focus management for the cart drawer and modals,
+  keyboard operability, visible focus rings, and color-contrast checks against the brand
+  palette. Target WCAG 2.1 AA.
+- **Mobile polish**: tighten the `/checkout` form on small screens (currently cramped),
+  ensure the country dropdown and address fields don't overflow, and give drag-to-cart a
+  mobile-friendly equivalent (it's desktop-only today).
+- **Checkout resilience**: loading spinner on the Stripe redirect button, a retry path on
+  checkout errors, and clearer messaging when email isn't configured (don't fail silently).
+- **Order history & tracking** (`/orders`, students; and a guest-accessible equivalent):
+  show the tracking number/carrier link once fulfilled, an empty state, and a **reorder**
+  button that repopulates the cart.
+- **Guest order lookup**: since guests have no account, add an order-status lookup by
+  email + order id (linked from the confirmation email) so guests can check status.
+- **Cart cross-device for students**: optionally sync the logged-in student cart to Redis so
+  it follows them across devices (localStorage stays the guest fallback). Keep the
+  clear-on-confirmed-success-only invariant.
+- **Thank-you page**: surface what happens next per pathway, and for guests keep the
+  webhook-confirmed status polling but add a graceful "still processing" state.
+
+**Acceptance:** A screen-reader user can complete a guest checkout; a student can reorder a
+past order in two clicks; a guest can look up their order status from the email.
+
+---
+
+## 6. Cross-cutting / engineering quality
+
+- **Tests**: there is currently **no test infrastructure**. Add a lightweight setup (Vitest
+  recommended for this stack) and cover the highest-risk logic first: server-side price
+  re-verification, stock enforcement/reservation/release, pathway filtering, coupon math,
+  and the Stripe webhook state machine. Add an `npm test` script.
+- **Types**: retire the legacy `ProductVariant.price` field cleanly once dual-pricing is
+  fully relied upon, or document why it stays.
+- **Docs**: update the stale `README.md` (says "COMING SOON"), and add `docs/` entries for
+  the inventory sync model and the Airtable schema additions.
+- **Error/observability**: make email-send failures visible to admins (they're silent
+  no-ops today when unconfigured — fine for dev, but log/surface in prod).
+
+---
+
+## 7. How to work
+
+1. **Plan first.** Propose an ordered backlog of small PRs across the four tracks; get the
+   ordering confirmed before large changes. Recommended first slice: accessibility +
+   catalog search/empty-states (low risk, high visible value), then the inventory system
+   (highest leverage, most care needed around the Stripe reservation lifecycle).
+2. **Respect the invariants in §0** on every change. When a change touches checkout or
+   Stripe, call out explicitly how the invariant is preserved.
+3. **Pathway-aware by default.** Every customer-facing change must be correct for both
+   `student` and `guest`. Every price must be re-derived server-side.
+4. **Keep Airtable safe.** New read sync must be cached and rate-limit-aware; all writes
+   stay fire-and-forget.
+5. **Ship verifiable increments.** Each PR: what changed, which acceptance criteria it meets,
+   how to test it, and confirmation the build (`npm run build`) and lint pass. Add tests for
+   new server logic.
+6. **Don't regress the brand.** Phantom Sans, the Hack Club palette, the playful stickers and
+   animations stay. Polish, don't sterilize.
+
+---
+
+## 7a. Pirate Ship / EasyPost shipping (shipped in the customer-flow track)
+
+Pirate Ship has no public API — it runs on **EasyPost**, so the integration talks
+to EasyPost for rates, labels, and tracking. It is config-gated and degrades to
+manual tracking entry when unconfigured, mirroring the email/Airtable pattern.
+
+**New env vars** (all optional; absence → manual-tracking-only fallback):
+- `EASYPOST_API_KEY` — EasyPost key (`EZTK…` test / `EZAK…` prod).
+- `SHIP_FROM_NAME`, `SHIP_FROM_COMPANY`, `SHIP_FROM_STREET1`, `SHIP_FROM_STREET2`,
+  `SHIP_FROM_CITY`, `SHIP_FROM_STATE`, `SHIP_FROM_ZIP`, `SHIP_FROM_COUNTRY`,
+  `SHIP_FROM_PHONE` — origin address postage ships from.
+- `NEXT_PUBLIC_API_URL` / `NEXTAUTH_URL` — used to build the guest tracking link
+  in confirmation emails (already present).
+
+**New Airtable `Orders` columns** (add manually for staff visibility): `Carrier`,
+`Tracking Number`, `Tracking URL`.
+
+**Files added:** `src/lib/shipping.ts`, `src/lib/orderStore.ts`,
+`src/app/api/admin/orders/[id]/shipping/route.ts`, `src/app/admin/orders/ShippingPanel.tsx`,
+`src/app/api/orders/lookup/route.ts`, `src/app/orders/track/page.tsx`,
+`src/app/api/cart/route.ts`. New `Order.shipment` field in `src/types/Order.ts`.
+
+## 7b. Inventory — Airtable-backed stock (shipped)
+
+Full model documented in `docs/INVENTORY.md`. Summary: Airtable `Products` is
+authoritative for the base stock number; Redis caches it (`inventory:{variantId}`)
+and holds the live `reserved` overlay (`inventory:{variantId}:reserved`).
+`available = max(0, stock - reserved)`. A variant with no stock number is
+unlimited (no migration needed). Guest/Stripe orders reserve → commit on paid /
+release on expired; student/points orders commit immediately (no reservation
+window). Both checkout paths fail closed on a proven oversell (409).
+
+**New Airtable `Products` column:** `Total Stock` (roll-up; per-variant stock
+lives inside `Variants JSON`, which the sync reads).
+
+**Files added:** `src/lib/inventory.ts`, `src/app/api/admin/inventory/route.ts`,
+`src/app/api/admin/inventory/sync/route.ts`, `src/app/admin/inventory/page.tsx`,
+`docs/INVENTORY.md`. New `Order.inventoryHold`; `available` on the product APIs.
+Enforcement wired into `checkout/stripe`, `webhooks/stripe`, `orders`, and admin
+refund. Backfill seeds inventory from existing Redis stock.
+
+## 7c. Catalog — discoverability (shipped)
+
+`/shop` now has **search** (name + category), **category chips** (driven by the
+real `Product.category`, which the admin form already manages), a **sort** control
+(featured / price asc·desc — pathway-aware / newest / name), **CardSkeleton**
+loading state for the initial fetch, and a **friendly empty state** with a clear-
+filters action. All filtering layers on top of the existing pathway filter, so it
+stays correct for both `student` and `guest`. `/api/products` now returns
+`category` and `createdAt` per product.
+
+## 8. Key files reference
+
+| Concern | Files |
+|---|---|
+| Pathway fork | `src/lib/usePathway.ts`, `src/lib/paymentUtils.ts` |
+| Types | `src/types/Order.ts`, `src/types/Admin.ts`, `src/types/Points.ts` |
+| Catalog API | `src/app/api/products/route.ts`, `src/app/api/products/[id]/route.ts` |
+| Student orders | `src/app/api/orders/route.ts`, `src/context/PointsContext.tsx` |
+| Guest/Stripe | `src/lib/stripe.ts`, `src/app/api/checkout/stripe/route.ts`, `src/app/api/checkout/stripe/status/route.ts`, `src/app/api/webhooks/stripe/route.ts`, `src/lib/guestOrders.ts` |
+| Airtable | `src/lib/airtableMirror.ts`, `src/lib/airtable.ts`, `src/app/api/admin/airtable-backfill/route.ts` |
+| Admin pages | `src/app/admin/**` (`page.tsx`, `orders/`, `products/`, `users/`, `coupons/`, `admins/`, `stats/`, `projects/`) |
+| Admin auth | `src/lib/adminAuth.ts`, `src/app/api/admin/me/route.ts` |
+| Storefront UI | `src/app/shop/page.tsx`, `src/app/products/[id]/page.tsx`, `src/app/checkout/page.tsx`, `src/app/thank-you/page.tsx`, `src/app/orders/page.tsx` |
+| Components | `src/app/components/Navigation.tsx`, `CartModal.tsx`, `ProductCard.tsx`, `Skeleton.tsx` |
+| Cart/state | `src/context/CartContext.tsx` |
+| Email | `src/lib/email.ts` |
+| Validation | `src/lib/productValidation.ts`, `src/lib/address.ts` |

--- a/docs/INVENTORY.md
+++ b/docs/INVENTORY.md
@@ -1,0 +1,103 @@
+# Inventory model
+
+How stock works in the Hack Club Shop, across Airtable, Redis, and the two
+checkout pathways. Read this before touching `src/lib/inventory.ts` or either
+checkout route.
+
+## The shape of the problem
+
+A variant can sell out, and we sell on two pathways at once:
+
+- **Student (points)** orders settle **instantly** — points are internal, there's
+  no external confirmation step. Stock can be decremented at order time.
+- **Guest (Stripe)** orders have an **in-flight window**: the order is created
+  `unpaid` when the Checkout Session is made, and only confirmed by the webhook
+  seconds-to-minutes later. During that window the units must be held so two
+  guests can't buy the last one, but they must be **released** if the session is
+  abandoned/expires.
+
+So stock is modelled as a base count plus an in-flight overlay.
+
+## Source of truth
+
+- **Airtable `Products` table is authoritative for the base stock number.** Staff
+  manage stock in the spreadsheet (per variant, inside `Variants JSON`, and as a
+  convenience `Total Stock` column). This is the number that means "how many we
+  physically have to sell".
+- **Redis is the operational store.** It caches the base stock for fast reads and
+  holds the live `reserved` overlay that Airtable never sees.
+
+Redis keys (per variant id):
+
+| Key | Meaning | Written by |
+|---|---|---|
+| `inventory:{variantId}` | `{ stock, syncedAt }` — cached base stock from Airtable/Redis product | sync, admin quick-adjust |
+| `inventory:{variantId}:reserved` | integer count of units held by in-flight Stripe sessions | reserve / release / commit |
+
+**Available to sell** = `max(0, stock − reserved)`.
+
+A variant with **no stock number set at all** (`stock === undefined`) is treated
+as **unlimited** — this preserves today's behaviour for every existing product
+until staff opt a variant into tracking by giving it a number.
+
+## Reservation lifecycle (guest / Stripe)
+
+```
+checkout/stripe POST   → reserve(variant, qty)      reserved += qty
+   │
+   ├─ payment completes → webhook checkout.session.completed
+   │                        → commit(variant, qty)  reserved -= qty ; stock -= qty
+   │
+   └─ session expires    → webhook checkout.session.expired
+                            → release(variant, qty) reserved -= qty
+```
+
+- `reserve` happens **after** price/availability validation but **before** the
+  Stripe session is created, and re-checks `available >= qty` so two simultaneous
+  checkouts can't both grab the last unit. If reservation fails, checkout is
+  rejected with a clear out-of-stock error and no Stripe session is made.
+- `commit` is idempotent-safe: the webhook already guards on
+  `paymentStatus === 'paid'`, so commit runs at most once per order.
+- `release` only runs while the order is still `unpaid` (the webhook already
+  checks this before marking the session expired/denied).
+- The reserved qty per order is stored on the order itself
+  (`order.inventoryHold`) so the webhook knows exactly what to commit/release
+  without recomputing from the cart.
+
+## Student / points orders
+
+Points orders settle in the same request, so there is no reservation window:
+they call `commit` directly (decrement available stock immediately) after points
+are validated and before the order is saved. If `available < qty`, the order is
+rejected before any points are deducted.
+
+## Conflict rule (reconciliation)
+
+Airtable is authoritative for the base number; Redis `reserved` is the in-flight
+overlay that Airtable doesn't model. The sync (`syncInventoryFromAirtable`) reads
+each variant's Airtable stock and overwrites the Redis `inventory:{variantId}`
+base **without touching `reserved`**. So:
+
+- Staff lowering stock in Airtable (e.g. after a manual count) wins on next sync.
+- In-flight reservations are preserved across a sync (they live in a separate
+  key), so a sync mid-checkout never double-frees a held unit.
+- When we `commit` a sale we decrement the cached base stock in Redis, which is
+  what gates further sales. Airtable is **not** decremented live — staff reconcile
+  the spreadsheet during their next count, and the next sync re-seeds Redis from
+  it. (`commitReserved` accepts an optional `mirror` callback if live write-back is
+  wired later; today none is passed, so Redis leads Airtable between counts.)
+
+Everything in `inventory.ts` is **fire-and-forget safe** like the email and
+Airtable-mirror layers: a Redis/Airtable hiccup degrades to "treat as available"
+rather than blocking a purchase, EXCEPT the explicit oversell check at checkout,
+which fails closed (rejects) only when it can positively prove `available < qty`.
+
+## Enabling stock tracking on a variant
+
+1. Give the variant a `stock` number (admin product form, or the
+   `/admin/inventory` quick-adjust, or the Airtable `Variants JSON`).
+2. Run a sync (the `/admin/inventory` "Sync from Airtable" button, or
+   `POST /api/admin/inventory/sync`).
+3. The storefront immediately reflects available stock and blocks oversells.
+
+Variants left without a number stay unlimited — no migration required.

--- a/src/app/admin/audit/page.tsx
+++ b/src/app/admin/audit/page.tsx
@@ -1,0 +1,117 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useSession, signIn } from 'next-auth/react';
+import Link from 'next/link';
+import { motion } from 'framer-motion';
+
+interface AuditEntry {
+    id: string;
+    action: string;
+    actorId: string;
+    actorEmail?: string;
+    target?: string;
+    summary: string;
+    timestamp: string;
+}
+
+const ACTION_COLOR: Record<string, string> = {
+    'order.approve': 'bg-blue-100 text-blue-800',
+    'order.deny': 'bg-red-100 text-red-800',
+    'order.fulfill': 'bg-green-100 text-green-800',
+    'order.refund': 'bg-orange-100 text-orange-800',
+    'order.ship': 'bg-cyan-100 text-cyan-800',
+    'order.mark-test': 'bg-gray-100 text-gray-600',
+    'order.unmark-test': 'bg-gray-100 text-gray-600',
+    'points.grant': 'bg-green-100 text-green-800',
+    'points.deduct': 'bg-red-100 text-red-800',
+    'inventory.adjust': 'bg-purple-100 text-purple-800',
+};
+
+export default function AuditAdmin() {
+    const { data: session, status } = useSession();
+    const [entries, setEntries] = useState<AuditEntry[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        if (status === 'unauthenticated') signIn('hackclub', { callbackUrl: '/admin/audit' });
+    }, [status]);
+
+    useEffect(() => {
+        if (!session) return;
+        (async () => {
+            try {
+                const res = await fetch('/api/admin/audit?limit=200');
+                if (!res.ok) {
+                    setError(res.status === 403 ? 'You don’t have permission to view the audit log.' : 'Failed to load audit log');
+                    return;
+                }
+                const data = await res.json();
+                setEntries(data.entries || []);
+            } catch {
+                setError('Failed to load audit log');
+            } finally {
+                setLoading(false);
+            }
+        })();
+    }, [session]);
+
+    if (status === 'loading' || (session && loading)) {
+        return (
+            <div className="min-h-screen flex items-center justify-center bg-hackclub-smoke">
+                <div className="text-hackclub-dark font-bold">Loading…</div>
+            </div>
+        );
+    }
+    if (!session) return null;
+
+    return (
+        <div className="min-h-screen bg-white text-hackclub-dark"
+            style={{
+                backgroundImage: 'linear-gradient(to right, #e0f2fe 1px, transparent 1px), linear-gradient(to bottom, #e0f2fe 1px, transparent 1px)',
+                backgroundSize: '30px 30px',
+            }}
+        >
+            <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+                <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.4 }}>
+                    <Link href="/admin" className="text-hackclub-slate hover:text-hackclub-dark mb-2 inline-block font-medium">
+                        ← Back to Dashboard
+                    </Link>
+                    <h1 className="text-5xl sm:text-6xl font-black text-hackclub-dark mb-2">Audit Log</h1>
+                    <p className="text-lg text-hackclub-slate font-medium mb-8">
+                        Who did what — refunds, point grants, status changes, shipping, and stock edits.
+                    </p>
+
+                    {error && (
+                        <div className="mb-4 p-4 bg-hackclub-red/10 border-2 border-hackclub-red rounded-xl">
+                            <p className="text-hackclub-red font-bold">{error}</p>
+                        </div>
+                    )}
+
+                    {entries.length === 0 && !error ? (
+                        <div className="text-center py-16 bg-white rounded-2xl shadow-lg border-2 border-hackclub-smoke">
+                            <p className="text-hackclub-muted font-bold">No actions recorded yet.</p>
+                        </div>
+                    ) : (
+                        <div className="bg-white rounded-2xl shadow-lg border-2 border-hackclub-smoke divide-y divide-hackclub-smoke">
+                            {entries.map((e) => (
+                                <div key={e.id} className="px-5 py-4 flex items-start gap-3">
+                                    <span className={`shrink-0 px-2.5 py-1 rounded-full text-xs font-bold ${ACTION_COLOR[e.action] || 'bg-gray-100 text-gray-700'}`}>
+                                        {e.action}
+                                    </span>
+                                    <div className="flex-1 min-w-0">
+                                        <p className="font-medium text-hackclub-dark">{e.summary}</p>
+                                        <p className="text-xs text-hackclub-muted mt-0.5">
+                                            {e.actorEmail || e.actorId} · {new Date(e.timestamp).toLocaleString()}
+                                        </p>
+                                    </div>
+                                </div>
+                            ))}
+                        </div>
+                    )}
+                </motion.div>
+            </div>
+        </div>
+    );
+}

--- a/src/app/admin/inventory/page.tsx
+++ b/src/app/admin/inventory/page.tsx
@@ -1,0 +1,246 @@
+'use client';
+
+import { useState, useEffect, useMemo } from 'react';
+import { useSession, signIn } from 'next-auth/react';
+import Link from 'next/link';
+import { motion } from 'framer-motion';
+
+interface Row {
+    productId: string;
+    productName: string;
+    variantId: string;
+    variantName: string;
+    size?: string;
+    color?: string;
+    stock: number | null;     // null = untracked/unlimited
+    reserved: number;
+    available: number | null;
+}
+
+const LOW_THRESHOLD = 5;
+
+export default function InventoryAdmin() {
+    const { data: session, status } = useSession();
+    const [rows, setRows] = useState<Row[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const [notice, setNotice] = useState<string | null>(null);
+    const [lowOnly, setLowOnly] = useState(false);
+    const [syncing, setSyncing] = useState(false);
+    const [savingId, setSavingId] = useState<string | null>(null);
+    const [edits, setEdits] = useState<Record<string, string>>({});
+
+    useEffect(() => {
+        if (status === 'unauthenticated') signIn('hackclub', { callbackUrl: '/admin/inventory' });
+    }, [status]);
+
+    const load = async () => {
+        try {
+            const res = await fetch('/api/admin/inventory');
+            if (!res.ok) {
+                setError(res.status === 403 ? 'You don’t have permission to manage inventory.' : 'Failed to load inventory');
+                return;
+            }
+            const data = await res.json();
+            setRows(data.rows || []);
+        } catch {
+            setError('Failed to load inventory');
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    useEffect(() => {
+        if (session) load();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [session]);
+
+    const sync = async () => {
+        setSyncing(true);
+        setError(null);
+        setNotice(null);
+        try {
+            const res = await fetch('/api/admin/inventory/sync', { method: 'POST' });
+            const data = await res.json();
+            if (!res.ok || data.ok === false) {
+                setError(data.error || 'Sync failed');
+            } else {
+                setNotice(`Synced ${data.synced} variant${data.synced === 1 ? '' : 's'} from Airtable.`);
+                await load();
+            }
+        } catch {
+            setError('Sync failed');
+        } finally {
+            setSyncing(false);
+        }
+    };
+
+    const saveStock = async (row: Row) => {
+        const raw = edits[row.variantId];
+        if (raw === undefined) return;
+        const trimmed = raw.trim();
+        const stock = trimmed === '' ? null : parseInt(trimmed, 10);
+        if (stock !== null && (Number.isNaN(stock) || stock < 0)) {
+            setError('Stock must be a non-negative number (or blank for unlimited).');
+            return;
+        }
+        setSavingId(row.variantId);
+        setError(null);
+        try {
+            const res = await fetch('/api/admin/inventory', {
+                method: 'PATCH',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ productId: row.productId, variantId: row.variantId, stock }),
+            });
+            const data = await res.json();
+            if (!res.ok) {
+                setError(data.error || 'Could not save');
+                return;
+            }
+            setRows(prev => prev.map(r =>
+                r.variantId === row.variantId
+                    ? { ...r, stock: data.stock, available: data.stock === null ? null : Math.max(0, data.stock - r.reserved) }
+                    : r,
+            ));
+            setEdits(prev => { const n = { ...prev }; delete n[row.variantId]; return n; });
+        } catch {
+            setError('Could not save');
+        } finally {
+            setSavingId(null);
+        }
+    };
+
+    const visible = useMemo(() => {
+        if (!lowOnly) return rows;
+        return rows.filter(r => r.available !== null && r.available <= LOW_THRESHOLD);
+    }, [rows, lowOnly]);
+
+    if (status === 'loading' || (session && loading)) {
+        return (
+            <div className="min-h-screen flex items-center justify-center bg-hackclub-smoke">
+                <div className="text-hackclub-dark font-bold">Loading…</div>
+            </div>
+        );
+    }
+    if (!session) return null;
+
+    return (
+        <div className="min-h-screen bg-white text-hackclub-dark"
+            style={{
+                backgroundImage: 'linear-gradient(to right, #e0f2fe 1px, transparent 1px), linear-gradient(to bottom, #e0f2fe 1px, transparent 1px)',
+                backgroundSize: '30px 30px',
+            }}
+        >
+            <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+                <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.4 }}>
+                    <Link href="/admin" className="text-hackclub-slate hover:text-hackclub-dark mb-2 inline-block font-medium">
+                        ← Back to Dashboard
+                    </Link>
+                    <div className="flex flex-wrap items-end justify-between gap-4 mb-2">
+                        <h1 className="text-5xl sm:text-6xl font-black text-hackclub-dark">Inventory</h1>
+                        <button
+                            type="button"
+                            onClick={sync}
+                            disabled={syncing}
+                            className="bg-hackclub-blue hover:bg-blue-600 text-white font-bold px-5 py-2.5 rounded-full transition-colors disabled:opacity-50"
+                        >
+                            {syncing ? 'Syncing…' : 'Sync from Airtable'}
+                        </button>
+                    </div>
+                    <p className="text-lg text-hackclub-slate font-medium mb-6">
+                        Stock is tracked per variant. Leave a stock field blank for unlimited. Airtable is the source of truth — edits here also update the product and re-sync to Airtable.
+                    </p>
+
+                    <div className="mb-6">
+                        <button
+                            type="button"
+                            onClick={() => setLowOnly(v => !v)}
+                            className={`inline-flex items-center gap-2 px-4 py-2 rounded-full text-sm font-bold border-2 transition-colors ${lowOnly ? 'bg-hackclub-orange text-white border-hackclub-orange' : 'bg-white text-hackclub-slate border-hackclub-smoke hover:border-hackclub-slate'}`}
+                            aria-pressed={lowOnly}
+                        >
+                            <span className={`w-2 h-2 rounded-full ${lowOnly ? 'bg-white' : 'bg-hackclub-muted'}`} />
+                            Low stock only (≤ {LOW_THRESHOLD})
+                        </button>
+                    </div>
+
+                    {error && (
+                        <div className="mb-4 p-4 bg-hackclub-red/10 border-2 border-hackclub-red rounded-xl">
+                            <p className="text-hackclub-red font-bold">{error}</p>
+                        </div>
+                    )}
+                    {notice && (
+                        <div className="mb-4 p-4 bg-hackclub-green/10 border-2 border-hackclub-green/40 rounded-xl">
+                            <p className="text-hackclub-green font-bold">{notice}</p>
+                        </div>
+                    )}
+
+                    <div className="bg-white rounded-2xl shadow-lg border-2 border-hackclub-smoke overflow-hidden">
+                        <div className="overflow-x-auto">
+                            <table className="w-full text-sm">
+                                <thead className="bg-hackclub-snow border-b-2 border-hackclub-smoke">
+                                    <tr className="text-left text-hackclub-muted font-black uppercase text-xs">
+                                        <th className="px-4 py-3">Product / Variant</th>
+                                        <th className="px-4 py-3 text-right">Stock</th>
+                                        <th className="px-4 py-3 text-right">Reserved</th>
+                                        <th className="px-4 py-3 text-right">Available</th>
+                                        <th className="px-4 py-3 text-right">Set stock</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {visible.length === 0 ? (
+                                        <tr><td colSpan={5} className="px-4 py-10 text-center text-hackclub-muted font-bold">No variants{lowOnly ? ' are low on stock' : ''}.</td></tr>
+                                    ) : visible.map(row => {
+                                        const untracked = row.stock === null;
+                                        const soldOut = row.available === 0;
+                                        const low = row.available !== null && row.available > 0 && row.available <= LOW_THRESHOLD;
+                                        return (
+                                            <tr key={row.variantId} className="border-b border-hackclub-smoke last:border-0">
+                                                <td className="px-4 py-3">
+                                                    <div className="font-bold text-hackclub-dark">{row.productName}</div>
+                                                    <div className="text-hackclub-muted">{row.variantName}{row.size ? ` · ${row.size}` : ''}{row.color ? ` · ${row.color}` : ''}</div>
+                                                </td>
+                                                <td className="px-4 py-3 text-right font-mono">{untracked ? <span className="text-hackclub-muted">∞</span> : row.stock}</td>
+                                                <td className="px-4 py-3 text-right font-mono">{row.reserved || 0}</td>
+                                                <td className="px-4 py-3 text-right font-mono">
+                                                    {untracked ? (
+                                                        <span className="text-hackclub-muted">∞</span>
+                                                    ) : soldOut ? (
+                                                        <span className="px-2 py-0.5 rounded-full text-xs font-black bg-hackclub-dark text-white">0</span>
+                                                    ) : low ? (
+                                                        <span className="px-2 py-0.5 rounded-full text-xs font-black bg-hackclub-orange text-white">{row.available}</span>
+                                                    ) : (
+                                                        <span className="text-hackclub-dark font-bold">{row.available}</span>
+                                                    )}
+                                                </td>
+                                                <td className="px-4 py-3">
+                                                    <div className="flex items-center justify-end gap-2">
+                                                        <input
+                                                            type="number"
+                                                            min={0}
+                                                            placeholder={untracked ? '∞' : String(row.stock)}
+                                                            value={edits[row.variantId] ?? ''}
+                                                            onChange={(e) => setEdits(prev => ({ ...prev, [row.variantId]: e.target.value }))}
+                                                            className="w-20 rounded-lg border-2 border-hackclub-smoke px-2 py-1 text-right font-mono focus:outline-none focus:border-hackclub-blue"
+                                                        />
+                                                        <button
+                                                            type="button"
+                                                            onClick={() => saveStock(row)}
+                                                            disabled={savingId === row.variantId || edits[row.variantId] === undefined}
+                                                            className="px-3 py-1.5 rounded-lg text-xs font-bold text-white bg-hackclub-green hover:bg-green-600 disabled:opacity-40"
+                                                        >
+                                                            {savingId === row.variantId ? '…' : 'Save'}
+                                                        </button>
+                                                    </div>
+                                                </td>
+                                            </tr>
+                                        );
+                                    })}
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </motion.div>
+            </div>
+        </div>
+    );
+}

--- a/src/app/admin/orders/page.tsx
+++ b/src/app/admin/orders/page.tsx
@@ -1,10 +1,15 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { useSession, signIn } from 'next-auth/react';
 import Link from 'next/link';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Order } from '../../../types/Order';
+import ShippingPanel from './ShippingPanel';
+
+const PAGE_SIZE = 25;
+type StatusFilter = 'all' | Order['status'];
+type PathwayFilter = 'all' | 'student' | 'guest';
 
 export default function OrdersAdmin() {
     const { data: session, status } = useSession();
@@ -14,6 +19,11 @@ export default function OrdersAdmin() {
     const [selectedOrder, setSelectedOrder] = useState<Order | null>(null);
     const [actingOrderId, setActingOrderId] = useState<string | null>(null);
     const [showTest, setShowTest] = useState(false);
+    // Search / filter / pagination.
+    const [query, setQuery] = useState('');
+    const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
+    const [pathwayFilter, setPathwayFilter] = useState<PathwayFilter>('all');
+    const [page, setPage] = useState(1);
 
     useEffect(() => {
         if (status === 'unauthenticated') {
@@ -100,6 +110,24 @@ export default function OrdersAdmin() {
         }
     };
 
+    // Filter pipeline: test toggle → status → pathway → free-text search.
+    // Computed before any early return so hook order stays stable.
+    const filteredOrders = useMemo(() => {
+        const orderSearchText = (o: Order) =>
+            [o.id, o.guestEmail, o.userId, ...o.items.map((i) => i.name), o.shipment?.trackingNumber]
+                .filter(Boolean)
+                .join(' ')
+                .toLowerCase();
+        const q = query.trim().toLowerCase();
+        return orders.filter((o) => {
+            if (!showTest && o.isTest) return false;
+            if (statusFilter !== 'all' && o.status !== statusFilter) return false;
+            if (pathwayFilter !== 'all' && o.pathway !== pathwayFilter) return false;
+            if (q && !orderSearchText(o).includes(q)) return false;
+            return true;
+        });
+    }, [orders, showTest, statusFilter, pathwayFilter, query]);
+
     if (status === 'loading' || (session && loading)) {
         return (
             <div className="min-h-screen flex items-center justify-center bg-hackclub-smoke">
@@ -108,7 +136,34 @@ export default function OrdersAdmin() {
         );
     }
 
-    const visibleOrders = showTest ? orders : orders.filter((o) => !o.isTest);
+    const totalPages = Math.max(1, Math.ceil(filteredOrders.length / PAGE_SIZE));
+    const clampedPage = Math.min(page, totalPages);
+    const visibleOrders = filteredOrders.slice((clampedPage - 1) * PAGE_SIZE, clampedPage * PAGE_SIZE);
+
+    const exportCsv = () => {
+        const headers = ['Order ID', 'Pathway', 'Status', 'Payment', 'Buyer', 'Items', 'Total (USD)', 'Points', 'Tracking', 'Created'];
+        const rows = filteredOrders.map((o) => [
+            o.id,
+            o.pathway,
+            o.status,
+            o.paymentStatus || '',
+            o.pathway === 'guest' ? o.guestEmail || '' : o.userId,
+            o.items.map((i) => `${i.quantity}x ${i.name}`).join('; '),
+            o.totalAmount.toFixed(2),
+            o.pointsSpent || 0,
+            o.shipment?.trackingNumber || '',
+            new Date(o.createdAt).toISOString(),
+        ]);
+        const esc = (v: unknown) => `"${String(v).replace(/"/g, '""')}"`;
+        const csv = [headers, ...rows].map((r) => r.map(esc).join(',')).join('\n');
+        const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = `orders-${new Date().toISOString().slice(0, 10)}.csv`;
+        a.click();
+        URL.revokeObjectURL(url);
+    };
 
     return (
         <div className="min-h-screen bg-white text-hackclub-dark"
@@ -136,16 +191,67 @@ export default function OrdersAdmin() {
                         View and manage all orders
                     </p>
 
-                    <div className="mb-12">
+                    {/* Search + filters + export */}
+                    <div className="flex flex-col lg:flex-row gap-3 mb-4">
+                        <div className="relative flex-1">
+                            <svg className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-hackclub-muted pointer-events-none" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+                            </svg>
+                            <input
+                                type="search"
+                                value={query}
+                                onChange={(e) => { setQuery(e.target.value); setPage(1); }}
+                                placeholder="Search by order #, email, user, item, tracking…"
+                                aria-label="Search orders"
+                                className="w-full pl-11 pr-4 py-2.5 rounded-full border-2 border-hackclub-smoke bg-white text-hackclub-dark font-medium focus:outline-none focus:border-hackclub-red transition-colors"
+                            />
+                        </div>
+                        <select
+                            value={statusFilter}
+                            onChange={(e) => { setStatusFilter(e.target.value as StatusFilter); setPage(1); }}
+                            aria-label="Filter by status"
+                            className="px-4 py-2.5 rounded-full border-2 border-hackclub-smoke bg-white text-hackclub-dark font-bold focus:outline-none focus:border-hackclub-red"
+                        >
+                            <option value="all">All statuses</option>
+                            <option value="pending">Pending</option>
+                            <option value="approved">Approved</option>
+                            <option value="fulfilled">Fulfilled</option>
+                            <option value="denied">Denied</option>
+                            <option value="refunded">Refunded</option>
+                        </select>
+                        <select
+                            value={pathwayFilter}
+                            onChange={(e) => { setPathwayFilter(e.target.value as PathwayFilter); setPage(1); }}
+                            aria-label="Filter by pathway"
+                            className="px-4 py-2.5 rounded-full border-2 border-hackclub-smoke bg-white text-hackclub-dark font-bold focus:outline-none focus:border-hackclub-red"
+                        >
+                            <option value="all">All pathways</option>
+                            <option value="student">Points</option>
+                            <option value="guest">Card</option>
+                        </select>
                         <button
                             type="button"
-                            onClick={() => setShowTest((prev) => !prev)}
+                            onClick={exportCsv}
+                            disabled={filteredOrders.length === 0}
+                            className="px-5 py-2.5 rounded-full text-sm font-bold bg-hackclub-blue hover:bg-blue-600 text-white transition-colors disabled:opacity-40"
+                        >
+                            Export CSV
+                        </button>
+                    </div>
+
+                    <div className="flex items-center justify-between mb-8">
+                        <button
+                            type="button"
+                            onClick={() => { setShowTest((prev) => !prev); setPage(1); }}
                             className={`inline-flex items-center gap-2 px-4 py-2 rounded-full text-sm font-bold border-2 transition-colors ${showTest ? 'bg-hackclub-dark text-white border-hackclub-dark' : 'bg-white text-hackclub-slate border-hackclub-smoke hover:border-hackclub-slate'}`}
                             aria-pressed={showTest}
                         >
                             <span className={`w-2 h-2 rounded-full ${showTest ? 'bg-hackclub-green' : 'bg-hackclub-muted'}`} />
                             Show test orders
                         </button>
+                        <p className="text-sm text-hackclub-muted font-bold">
+                            {filteredOrders.length} order{filteredOrders.length === 1 ? '' : 's'}
+                        </p>
                     </div>
 
                     {error && (
@@ -231,7 +337,7 @@ export default function OrdersAdmin() {
                                                 actions.push({ action: 'approve', label: 'Approve', className: 'bg-hackclub-green hover:bg-green-600' });
                                                 actions.push({ action: 'deny', label: 'Deny', className: 'bg-hackclub-red hover:bg-red-600' });
                                             } else if (order.status === 'approved') {
-                                                actions.push({ action: 'fulfill', label: 'Fulfill', className: 'bg-hackclub-blue hover:bg-blue-600' });
+                                                // Fulfillment now goes through the shipping panel (below); keep refund here.
                                                 actions.push({ action: 'refund', label: refundLabel, className: 'bg-hackclub-red hover:bg-red-600' });
                                             } else if (order.status === 'fulfilled') {
                                                 actions.push({ action: 'refund', label: refundLabel, className: 'bg-hackclub-red hover:bg-red-600' });
@@ -239,9 +345,16 @@ export default function OrdersAdmin() {
 
                                             const testAction: 'mark-test' | 'unmark-test' = order.isTest ? 'unmark-test' : 'mark-test';
                                             const testLabel = order.isTest ? 'Untest' : 'Mark test';
+                                            const applyUpdate = (updated: Order) => {
+                                                setOrders((prev) => prev.map((o) => (o.id === updated.id ? updated : o)));
+                                                setSelectedOrder((prev) => (prev && prev.id === updated.id ? updated : prev));
+                                            };
 
                                             return (
                                                 <div className="mt-4 flex flex-wrap gap-2">
+                                                    {order.status === 'approved' && (
+                                                        <ShippingPanel order={order} onShipped={applyUpdate} onError={setError} />
+                                                    )}
                                                     {actions.map(({ action, label, className }) => (
                                                         <button
                                                             key={action}
@@ -264,6 +377,38 @@ export default function OrdersAdmin() {
                                                 </div>
                                             );
                                         })()}
+
+                                        {order.shipment?.trackingNumber && (
+                                            <div className="mt-4 pt-4 border-t-2 border-hackclub-smoke flex flex-wrap items-center gap-x-4 gap-y-1 text-sm">
+                                                <span className="font-bold text-hackclub-dark">
+                                                    📦 {order.shipment.carrier || 'Shipped'}{order.shipment.service ? ` ${order.shipment.service}` : ''}
+                                                </span>
+                                                {order.shipment.trackingUrl ? (
+                                                    <a
+                                                        href={order.shipment.trackingUrl}
+                                                        target="_blank"
+                                                        rel="noreferrer"
+                                                        onClick={(e) => e.stopPropagation()}
+                                                        className="font-mono text-hackclub-blue hover:underline"
+                                                    >
+                                                        {order.shipment.trackingNumber}
+                                                    </a>
+                                                ) : (
+                                                    <span className="font-mono text-hackclub-slate">{order.shipment.trackingNumber}</span>
+                                                )}
+                                                {order.shipment.labelUrl && (
+                                                    <a
+                                                        href={order.shipment.labelUrl}
+                                                        target="_blank"
+                                                        rel="noreferrer"
+                                                        onClick={(e) => e.stopPropagation()}
+                                                        className="text-hackclub-slate hover:text-hackclub-dark font-bold underline"
+                                                    >
+                                                        Label PDF
+                                                    </a>
+                                                )}
+                                            </div>
+                                        )}
 
                                         {selectedOrder?.id === order.id && order.statusHistory && order.statusHistory.length > 0 && (
                                             <motion.div
@@ -289,6 +434,30 @@ export default function OrdersAdmin() {
                             )}
                         </AnimatePresence>
                     </div>
+
+                    {totalPages > 1 && (
+                        <div className="flex items-center justify-center gap-4 mt-8">
+                            <button
+                                type="button"
+                                onClick={() => setPage((p) => Math.max(1, p - 1))}
+                                disabled={clampedPage <= 1}
+                                className="px-4 py-2 rounded-full text-sm font-bold border-2 border-hackclub-smoke text-hackclub-slate hover:border-hackclub-slate disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+                            >
+                                ← Prev
+                            </button>
+                            <span className="text-sm font-bold text-hackclub-muted">
+                                Page {clampedPage} of {totalPages}
+                            </span>
+                            <button
+                                type="button"
+                                onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+                                disabled={clampedPage >= totalPages}
+                                className="px-4 py-2 rounded-full text-sm font-bold border-2 border-hackclub-smoke text-hackclub-slate hover:border-hackclub-slate disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+                            >
+                                Next →
+                            </button>
+                        </div>
+                    )}
                 </motion.div>
             </div>
         </div>

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -153,6 +153,23 @@ export default function AdminDashboard() {
                             </Link>
                         </motion.div>
 
+                        {/* Inventory */}
+                        <motion.div
+                            initial={{ opacity: 0, y: 20 }}
+                            animate={{ opacity: 1, y: 0 }}
+                            transition={{ delay: 0.15 }}
+                        >
+                            <Link href="/admin/inventory">
+                                <div className="bg-white rounded-2xl shadow-lg border-2 border-hackclub-smoke p-6 hover:shadow-xl hover:border-hackclub-cyan transition-all cursor-pointer group">
+                                    <div className="w-12 h-12 bg-hackclub-cyan/10 rounded-lg flex items-center justify-center mb-4 group-hover:bg-hackclub-cyan/20 transition-colors">
+                                        <Icon glyph="package" size={24} style={{ color: 'var(--hackclub-cyan, #5bc0de)' }} />
+                                    </div>
+                                    <h3 className="text-xl font-black text-hackclub-dark mb-2">Inventory</h3>
+                                    <p className="text-hackclub-slate text-sm">Track stock, sync from Airtable, fix oversells</p>
+                                </div>
+                            </Link>
+                        </motion.div>
+
                         {/* Coupons */}
                         <motion.div
                             initial={{ opacity: 0, y: 20 }}
@@ -217,6 +234,23 @@ export default function AdminDashboard() {
                                     </div>
                                     <h3 className="text-xl font-black text-hackclub-dark mb-2">Statistics</h3>
                                     <p className="text-hackclub-slate text-sm">View sales and order statistics</p>
+                                </div>
+                            </Link>
+                        </motion.div>
+
+                        {/* Audit Log */}
+                        <motion.div
+                            initial={{ opacity: 0, y: 20 }}
+                            animate={{ opacity: 1, y: 0 }}
+                            transition={{ delay: 0.55 }}
+                        >
+                            <Link href="/admin/audit">
+                                <div className="bg-white rounded-2xl shadow-lg border-2 border-hackclub-smoke p-6 hover:shadow-xl hover:border-hackclub-slate transition-all cursor-pointer group">
+                                    <div className="w-12 h-12 bg-hackclub-slate/10 rounded-lg flex items-center justify-center mb-4 group-hover:bg-hackclub-slate/20 transition-colors">
+                                        <Icon glyph="history" size={24} style={{ color: 'var(--hackclub-slate, #3c4858)' }} />
+                                    </div>
+                                    <h3 className="text-xl font-black text-hackclub-dark mb-2">Audit Log</h3>
+                                    <p className="text-hackclub-slate text-sm">Who did what — refunds, points, status, stock</p>
                                 </div>
                             </Link>
                         </motion.div>

--- a/src/app/admin/stats/page.tsx
+++ b/src/app/admin/stats/page.tsx
@@ -11,6 +11,13 @@ interface StatsData {
     totalRevenue: string;
     ordersByStatus: Record<string, number>;
     topProducts: Array<{ id: string; name: string; quantity: number; revenue: number }>;
+    cashRevenue: string;
+    pointsSpent: number;
+    guestOrderCount: number;
+    studentOrderCount: number;
+    timeSeries: Array<{ date: string; revenue: number; orders: number }>;
+    abandonedSessions: number;
+    lowStockCount: number;
 }
 
 export default function StatsAdmin() {
@@ -148,6 +155,45 @@ export default function StatsAdmin() {
                                 </motion.div>
                             </div>
 
+                            {/* Operational cards */}
+                            <div className="grid grid-cols-2 md:grid-cols-4 gap-6">
+                                <div className="bg-white rounded-2xl shadow-lg border-2 border-hackclub-smoke p-6">
+                                    <p className="text-hackclub-muted font-bold text-sm">Cash Revenue</p>
+                                    <p className="text-3xl font-black text-hackclub-green mt-2">${stats.cashRevenue}</p>
+                                    <p className="text-xs text-hackclub-slate mt-1">{stats.guestOrderCount} card order{stats.guestOrderCount === 1 ? '' : 's'}</p>
+                                </div>
+                                <div className="bg-white rounded-2xl shadow-lg border-2 border-hackclub-smoke p-6">
+                                    <p className="text-hackclub-muted font-bold text-sm">Points Spent</p>
+                                    <p className="text-3xl font-black text-hackclub-blue mt-2">{stats.pointsSpent.toLocaleString()}</p>
+                                    <p className="text-xs text-hackclub-slate mt-1">{stats.studentOrderCount} points order{stats.studentOrderCount === 1 ? '' : 's'}</p>
+                                </div>
+                                <Link href="/admin/inventory">
+                                    <div className={`bg-white rounded-2xl shadow-lg border-2 p-6 transition-colors ${stats.lowStockCount > 0 ? 'border-hackclub-orange/40 hover:border-hackclub-orange' : 'border-hackclub-smoke hover:border-hackclub-slate'}`}>
+                                        <p className="text-hackclub-muted font-bold text-sm">Low Stock</p>
+                                        <p className={`text-3xl font-black mt-2 ${stats.lowStockCount > 0 ? 'text-hackclub-orange' : 'text-hackclub-dark'}`}>{stats.lowStockCount}</p>
+                                        <p className="text-xs text-hackclub-slate mt-1">variants ≤ 5 left</p>
+                                    </div>
+                                </Link>
+                                <div className="bg-white rounded-2xl shadow-lg border-2 border-hackclub-smoke p-6">
+                                    <p className="text-hackclub-muted font-bold text-sm">Abandoned</p>
+                                    <p className="text-3xl font-black text-hackclub-dark mt-2">{stats.abandonedSessions}</p>
+                                    <p className="text-xs text-hackclub-slate mt-1">expired card sessions</p>
+                                </div>
+                            </div>
+
+                            {/* Revenue over time */}
+                            {stats.timeSeries.length > 0 && (
+                                <motion.div
+                                    initial={{ opacity: 0, y: 20 }}
+                                    animate={{ opacity: 1, y: 0 }}
+                                    transition={{ delay: 0.35 }}
+                                    className="bg-white rounded-2xl shadow-lg border-2 border-hackclub-smoke p-6"
+                                >
+                                    <h2 className="text-2xl font-black text-hackclub-dark mb-6">Revenue over time</h2>
+                                    <RevenueChart data={stats.timeSeries} />
+                                </motion.div>
+                            )}
+
                             {/* Orders by Status */}
                             <motion.div
                                 initial={{ opacity: 0, y: 20 }}
@@ -201,6 +247,35 @@ export default function StatsAdmin() {
                         </div>
                     )}
                 </motion.div>
+            </div>
+        </div>
+    );
+}
+
+/**
+ * Lightweight inline-SVG bar chart for daily revenue. No external chart library
+ * (keeps the bundle small and is CSP-safe). Bars scale to the max day; hover
+ * shows the exact value via the native title tooltip.
+ */
+function RevenueChart({ data }: { data: Array<{ date: string; revenue: number; orders: number }> }) {
+    const max = Math.max(1, ...data.map((d) => d.revenue));
+    // Cap the number of labelled ticks so dense ranges stay readable.
+    const labelEvery = Math.ceil(data.length / 8);
+    return (
+        <div className="overflow-x-auto">
+            <div className="flex items-end gap-1.5 min-w-full h-48" style={{ minWidth: `${data.length * 16}px` }}>
+                {data.map((d, i) => (
+                    <div key={d.date} className="flex-1 flex flex-col items-center justify-end group" style={{ minWidth: '10px' }}>
+                        <div
+                            className="w-full bg-hackclub-red/80 group-hover:bg-hackclub-red rounded-t transition-colors"
+                            style={{ height: `${Math.max(2, (d.revenue / max) * 100)}%` }}
+                            title={`${d.date}: $${d.revenue.toFixed(2)} · ${d.orders} order${d.orders === 1 ? '' : 's'}`}
+                        />
+                        <span className="text-[9px] text-hackclub-muted mt-1 whitespace-nowrap" style={{ visibility: i % labelEvery === 0 ? 'visible' : 'hidden' }}>
+                            {d.date.slice(5)}
+                        </span>
+                    </div>
+                ))}
             </div>
         </div>
     );

--- a/src/app/api/admin/airtable-backfill/route.ts
+++ b/src/app/api/admin/airtable-backfill/route.ts
@@ -11,6 +11,7 @@ import {
     mirrorUser,
     mirrorCoupon,
 } from '../../../../lib/airtableMirror';
+import { setStock } from '../../../../lib/inventory';
 
 const redis = new Redis({
     url: process.env.UPSTASH_REDIS_REST_URL!,
@@ -41,16 +42,24 @@ export async function POST() {
     // ~4 req/sec throttle to stay under Airtable's 5/sec limit.
     const throttle = () => new Promise((r) => setTimeout(r, 250));
 
-    const counts = { products: 0, coupons: 0, users: 0, orders: 0, errors: 0 };
+    const counts = { products: 0, coupons: 0, users: 0, orders: 0, variantsStocked: 0, errors: 0 };
 
     try {
-        // Products
+        // Products — also seed the inventory cache from each variant's stock so
+        // tracking works immediately without waiting for the first Airtable sync.
         const productKeys = await redis.keys('product:*');
         for (const key of productKeys) {
             const product = await redis.get<Product>(key);
             if (product?.id) {
                 await mirrorProduct(product);
                 counts.products++;
+                for (const v of product.variants || []) {
+                    const variantId = String(v.variant_id || v.id);
+                    if (!variantId) continue;
+                    const stock = typeof v.stock === 'number' ? v.stock : null;
+                    await setStock(variantId, stock);
+                    if (stock !== null) counts.variantsStocked++;
+                }
                 await throttle();
             }
         }

--- a/src/app/api/admin/audit/route.ts
+++ b/src/app/api/admin/audit/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '../../auth/[...nextauth]/route';
+import { requireAdminPermission } from '../../../../lib/adminAuth';
+import { readAudit } from '../../../../lib/auditLog';
+
+/**
+ * Read the admin audit trail. Gated on canViewStats so any admin who can see the
+ * dashboard can see who did what; the actions themselves stay behind their own
+ * permission gates.
+ */
+export async function GET(request: Request) {
+    const session = await getServerSession(authOptions);
+    const can = await requireAdminPermission(session, 'canViewStats');
+    if (!can.allowed) return NextResponse.json({ error: 'Unauthorized' }, { status: 403 });
+
+    const limit = Math.min(500, Math.max(1, parseInt(new URL(request.url).searchParams.get('limit') || '100', 10) || 100));
+    const entries = await readAudit(limit);
+    return NextResponse.json({ entries });
+}

--- a/src/app/api/admin/inventory/route.ts
+++ b/src/app/api/admin/inventory/route.ts
@@ -1,0 +1,107 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { Redis } from '@upstash/redis';
+import { authOptions } from '../../auth/[...nextauth]/route';
+import { requireAdminPermission } from '../../../../lib/adminAuth';
+import { Product } from '../../../../types/Admin';
+import { mirrorProduct } from '../../../../lib/airtableMirror';
+import { getVariantStocks, setStock } from '../../../../lib/inventory';
+import { recordAudit } from '../../../../lib/auditLog';
+
+const redis = new Redis({
+    url: process.env.UPSTASH_REDIS_REST_URL!,
+    token: process.env.UPSTASH_REDIS_REST_TOKEN!,
+});
+
+/**
+ * Admin inventory view + quick-adjust. Lists every variant across all products
+ * with its live stock / reserved / available, and lets staff set a variant's
+ * stock number directly (which updates both the product record and the inventory
+ * cache, then re-mirrors the product to Airtable so the spreadsheet matches).
+ */
+export async function GET() {
+    const session = await getServerSession(authOptions);
+    const can = await requireAdminPermission(session, 'canManageProducts');
+    if (!can.allowed) return NextResponse.json({ error: 'Unauthorized' }, { status: 403 });
+
+    const keys = await redis.keys('product:*');
+    const products: Product[] = [];
+    for (const key of keys) {
+        const p = await redis.get<Product>(key);
+        if (p) products.push(p);
+    }
+
+    const variantIds = products.flatMap(p =>
+        (p.variants || []).map(v => String(v.variant_id || v.id)),
+    );
+    const stocks = await getVariantStocks(variantIds);
+
+    const rows = products.flatMap(p =>
+        (p.variants || []).map(v => {
+            const variantId = String(v.variant_id || v.id);
+            const s = stocks[variantId];
+            return {
+                productId: p.id,
+                productName: p.name,
+                variantId,
+                variantName: v.name,
+                size: v.size,
+                color: v.color,
+                stock: s?.stock ?? null,      // null = untracked/unlimited
+                reserved: s?.reserved ?? 0,
+                available: s?.available ?? null,
+            };
+        }),
+    );
+
+    return NextResponse.json({ rows });
+}
+
+export async function PATCH(request: Request) {
+    const session = await getServerSession(authOptions);
+    const can = await requireAdminPermission(session, 'canManageProducts');
+    if (!can.allowed) return NextResponse.json({ error: 'Unauthorized' }, { status: 403 });
+
+    const { productId, variantId, stock } = (await request.json()) as {
+        productId?: string;
+        variantId?: string;
+        stock?: number | null;
+    };
+    if (!productId || !variantId) {
+        return NextResponse.json({ error: 'productId and variantId are required' }, { status: 400 });
+    }
+
+    const product = await redis.get<Product>(`product:${productId}`);
+    if (!product) return NextResponse.json({ error: 'Product not found' }, { status: 404 });
+
+    // Normalize: empty/negative/NaN → untracked (unlimited).
+    const next = stock === null || stock === undefined || Number.isNaN(stock) || stock < 0
+        ? undefined
+        : Math.floor(stock);
+
+    let matched = false;
+    product.variants = (product.variants || []).map(v => {
+        if (String(v.variant_id || v.id) === String(variantId)) {
+            matched = true;
+            return { ...v, stock: next };
+        }
+        return v;
+    });
+    if (!matched) return NextResponse.json({ error: 'Variant not found' }, { status: 404 });
+
+    product.updatedAt = new Date();
+    await redis.set(`product:${productId}`, product);
+    await setStock(variantId, next === undefined ? null : next);
+    void mirrorProduct(product);
+
+    void recordAudit({
+        action: 'inventory.adjust',
+        actorId: session?.user?.id || 'unknown',
+        actorEmail: session?.user?.email || undefined,
+        target: variantId,
+        summary: `Set stock for "${product.name}" variant ${variantId} to ${next === undefined ? 'unlimited' : next}`,
+        metadata: { productId, stock: next ?? null },
+    });
+
+    return NextResponse.json({ ok: true, stock: next ?? null });
+}

--- a/src/app/api/admin/inventory/sync/route.ts
+++ b/src/app/api/admin/inventory/sync/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '../../../auth/[...nextauth]/route';
+import { requireAdminPermission } from '../../../../../lib/adminAuth';
+import { syncInventoryFromAirtable, isInventorySyncConfigured } from '../../../../../lib/inventory';
+
+/**
+ * Pull variant stock from Airtable into the Redis inventory cache on demand.
+ * Bypasses the min-interval guard (force) since an admin explicitly asked.
+ */
+export async function POST() {
+    const session = await getServerSession(authOptions);
+    const can = await requireAdminPermission(session, 'canManageProducts');
+    if (!can.allowed) return NextResponse.json({ error: 'Unauthorized' }, { status: 403 });
+
+    if (!isInventorySyncConfigured()) {
+        return NextResponse.json({ ok: false, error: 'Airtable is not configured.' }, { status: 200 });
+    }
+
+    const result = await syncInventoryFromAirtable(true);
+    if (!result.ok) {
+        return NextResponse.json({ ok: false, error: result.reason || 'Sync failed' }, { status: 502 });
+    }
+    return NextResponse.json({ ok: true, synced: result.synced });
+}

--- a/src/app/api/admin/orders/[id]/route.ts
+++ b/src/app/api/admin/orders/[id]/route.ts
@@ -6,6 +6,8 @@ import { requireAdminPermission } from '../../../../../lib/adminAuth';
 import { getGuestOrder, updateGuestOrder } from '../../../../../lib/guestOrders';
 import { mirrorOrder } from '../../../../../lib/airtableMirror';
 import { getStripe, isStripeConfigured } from '../../../../../lib/stripe';
+import { restock } from '../../../../../lib/inventory';
+import { recordAudit, AuditAction } from '../../../../../lib/auditLog';
 import { sendEmail, buildStatusUpdate } from '../../../../../lib/email';
 import { Order, OrderStatusUpdate } from '../../../../../types/Order';
 import { PointsTransaction } from '../../../../../types/Points';
@@ -41,6 +43,11 @@ export async function POST(request: Request, { params }: { params: { id: string 
     }
 
     const orderId = params.id;
+    const actorId = session?.user?.id || 'unknown';
+    const actorEmail = session?.user?.email || undefined;
+    const audit = (action: AuditAction, summary: string, metadata?: Record<string, unknown>) =>
+        void recordAudit({ action, actorId, actorEmail, target: orderId, summary, metadata });
+
     const { action, message } = (await request.json()) as { action: Action; message?: string };
 
     const isTestToggle = action === 'mark-test' || action === 'unmark-test';
@@ -55,11 +62,13 @@ export async function POST(request: Request, { params }: { params: { id: string 
         if (guest) {
             const updated = await updateGuestOrder(orderId, { isTest });
             if (updated) void mirrorOrder(updated);
+            audit(`order.${action}` as AuditAction, `${isTest ? 'Marked' : 'Unmarked'} order #${orderId.slice(-8)} as test`);
             return NextResponse.json({ order: updated });
         }
         const updated = await setStudentOrderField(orderId, { isTest });
         if (!updated) return NextResponse.json({ error: 'Order not found' }, { status: 404 });
         void mirrorOrder(updated);
+        audit(`order.${action}` as AuditAction, `${isTest ? 'Marked' : 'Unmarked'} order #${orderId.slice(-8)} as test`);
         return NextResponse.json({ order: updated });
     }
 
@@ -81,6 +90,10 @@ export async function POST(request: Request, { params }: { params: { id: string 
                         return NextResponse.json({ error: 'Stripe refund failed. Check the dashboard.' }, { status: 502 });
                     }
                 }
+                // Return the sold units to stock (best-effort).
+                if (guest.inventoryHold && guest.inventoryHold.length > 0) {
+                    void restock(guest.inventoryHold);
+                }
             }
 
             const updated = await updateGuestOrder(orderId, {
@@ -92,6 +105,7 @@ export async function POST(request: Request, { params }: { params: { id: string 
                 void mirrorOrder(updated);
                 if (updated.guestEmail) void sendEmail(buildStatusUpdate(updated, updated.guestEmail, message));
             }
+            audit(`order.${action}` as AuditAction, `${actionLabel(action)} guest order #${orderId.slice(-8)} ($${guest.totalAmount.toFixed(2)})`, message ? { message } : undefined);
             return NextResponse.json({ order: updated });
         }
 
@@ -102,6 +116,7 @@ export async function POST(request: Request, { params }: { params: { id: string 
         }
         if (result.email) void sendEmail(buildStatusUpdate(result.order, result.email, message));
         void mirrorOrder(result.order);
+        audit(`order.${action}` as AuditAction, `${actionLabel(action)} points order #${orderId.slice(-8)}${result.pointsRefunded ? ` (+${result.pointsRefunded} pts refunded)` : ''}`, message ? { message } : undefined);
         return NextResponse.json({ order: result.order, pointsRefunded: result.pointsRefunded });
     } catch (error) {
         console.error('[Admin order] Error:', error);
@@ -111,6 +126,10 @@ export async function POST(request: Request, { params }: { params: { id: string 
 
 function historyEntry(status: Order['status'], message?: string): OrderStatusUpdate {
     return { status, timestamp: new Date(), ...(message ? { message } : {}) };
+}
+
+function actionLabel(action: StatusAction): string {
+    return { approve: 'Approved', deny: 'Denied', fulfill: 'Fulfilled', refund: 'Refunded' }[action];
 }
 
 /**

--- a/src/app/api/admin/stats/route.ts
+++ b/src/app/api/admin/stats/route.ts
@@ -4,6 +4,8 @@ import { Redis } from '@upstash/redis';
 import { authOptions } from '../../auth/[...nextauth]/route';
 import { requireAdminPermission } from '../../../../lib/adminAuth';
 import { Order } from '../../../../types/Order';
+import { Product } from '../../../../types/Admin';
+import { getVariantStocks } from '../../../../lib/inventory';
 
 const redis = new Redis({
     url: process.env.UPSTASH_REDIS_REST_URL!,
@@ -94,12 +96,55 @@ export async function GET(request: Request) {
             .slice(0, 10)
             .map(([name, data]) => ({ id: name, ...data }));
 
+        // Points vs cash split (real orders): cash revenue (USD) vs points spent.
+        const cashRevenue = realOrders.filter(o => o.pathway === 'guest').reduce((s, o) => s + o.totalAmount, 0);
+        const pointsSpent = realOrders.filter(o => o.pathway === 'student').reduce((s, o) => s + (o.pointsSpent || 0), 0);
+        const guestOrderCount = realOrders.filter(o => o.pathway === 'guest').length;
+        const studentOrderCount = realOrders.filter(o => o.pathway === 'student').length;
+
+        // Revenue + order count over time, bucketed by day across the period.
+        const dayBuckets: Record<string, { revenue: number; orders: number }> = {};
+        for (const o of realOrders) {
+            const day = new Date(o.createdAt).toISOString().slice(0, 10);
+            if (!dayBuckets[day]) dayBuckets[day] = { revenue: 0, orders: 0 };
+            dayBuckets[day].revenue += o.totalAmount;
+            dayBuckets[day].orders += 1;
+        }
+        const timeSeries = Object.entries(dayBuckets)
+            .sort((a, b) => a[0].localeCompare(b[0]))
+            .map(([date, v]) => ({ date, revenue: Number(v.revenue.toFixed(2)), orders: v.orders }));
+
+        // Abandoned/expired guest sessions (orders denied while still unpaid).
+        const abandonedSessions = orders.filter(o => o.pathway === 'guest' && o.paymentStatus === 'unpaid' && o.status === 'denied').length;
+
+        // Low-stock count across tracked variants (available ≤ 5).
+        let lowStockCount = 0;
+        try {
+            const productKeys = await redis.keys('product:*');
+            const variantIds: string[] = [];
+            for (const key of productKeys) {
+                const p = await redis.get<Product>(key);
+                for (const v of p?.variants || []) variantIds.push(String(v.variant_id || v.id));
+            }
+            const stocks = await getVariantStocks(variantIds);
+            lowStockCount = Object.values(stocks).filter(s => s.available !== null && s.available <= 5).length;
+        } catch {
+            // Best-effort; leave at 0 if inventory read fails.
+        }
+
         return NextResponse.json({
             period,
             totalOrders,
             totalRevenue: totalRevenue.toFixed(2),
             ordersByStatus,
             topProducts,
+            cashRevenue: cashRevenue.toFixed(2),
+            pointsSpent,
+            guestOrderCount,
+            studentOrderCount,
+            timeSeries,
+            abandonedSessions,
+            lowStockCount,
             orders: filteredOrders,
         });
     } catch {

--- a/src/app/api/admin/users/[id]/points/route.ts
+++ b/src/app/api/admin/users/[id]/points/route.ts
@@ -4,6 +4,7 @@ import { Redis } from '@upstash/redis';
 import { authOptions } from '../../../../auth/[...nextauth]/route';
 import { requireAdminPermission } from '../../../../../../lib/adminAuth';
 import { mirrorUser } from '../../../../../../lib/airtableMirror';
+import { recordAudit } from '../../../../../../lib/auditLog';
 
 const redis = new Redis({
     url: process.env.UPSTASH_REDIS_REST_URL!,
@@ -50,6 +51,15 @@ export async function PUT(
         const transactions = (await redis.get<any[]>(txKey(userId))) || [];
         transactions.unshift(transaction);
         await redis.set(txKey(userId), transactions);
+
+        void recordAudit({
+            action: amount >= 0 ? 'points.grant' : 'points.deduct',
+            actorId: session?.user?.id || 'unknown',
+            actorEmail: session?.user?.email || undefined,
+            target: userId,
+            summary: `${amount >= 0 ? 'Granted' : 'Deducted'} ${Math.abs(amount)} pts ${amount >= 0 ? 'to' : 'from'} ${userId} (→ ${newBalance}). Reason: ${reason}`,
+            metadata: { amount, previousBalance: currentBalance, newBalance, reason },
+        });
 
         return NextResponse.json({
             userId,

--- a/src/app/api/checkout/stripe/route.ts
+++ b/src/app/api/checkout/stripe/route.ts
@@ -4,6 +4,7 @@ import { validateCartItems, getProductById } from '../../../../lib/productValida
 import { isStructuredAddress, validateAddress } from '../../../../lib/address';
 import { rateLimit, rateLimitResponse } from '../../../../lib/rateLimit';
 import { saveGuestOrder } from '../../../../lib/guestOrders';
+import { reserve, release, StockLine } from '../../../../lib/inventory';
 import { Order, ShippingAddress } from '../../../../types/Order';
 
 /**
@@ -67,6 +68,25 @@ export async function POST(request: Request) {
 
         const itemsCashTotal = validation.verifiedCashTotal!;
 
+        // Reserve stock before creating the Stripe session, so two guests can't
+        // both buy the last unit during the in-flight payment window. Untracked
+        // variants are unlimited and always succeed. The hold is released by the
+        // webhook on expiry, or committed to a sale on payment.
+        const holdLines: StockLine[] = validation.items!.map(i => ({ variantId: i.variantId, quantity: i.quantity }));
+        const reservation = await reserve(holdLines);
+        if (!reservation.ok) {
+            const oversold = validation.items!.find(i => i.variantId === reservation.variantId);
+            const name = oversold?.name || 'An item';
+            return NextResponse.json(
+                {
+                    error: reservation.available > 0
+                        ? `Only ${reservation.available} of ${name} left — please reduce the quantity.`
+                        : `${name} just sold out.`,
+                },
+                { status: 409 },
+            );
+        }
+
         // Resolve the verified USD shipping cost from the first item's product.
         let shippingCost = 0;
         const firstProduct = await getProductById(items[0].id);
@@ -81,6 +101,10 @@ export async function POST(request: Request) {
         const origin = request.headers.get('origin') || process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000';
 
         const orderId = `order_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+
+        // From here on, a failure must release the stock we just reserved so a
+        // crashed checkout doesn't leak held units.
+        try {
 
         // Stripe only accepts absolute http(s) image URLs; a relative path (e.g.
         // "/images/x.svg") makes session creation fail entirely. Pass images only
@@ -147,15 +171,21 @@ export async function POST(request: Request) {
             stripeSessionId: session.id,
             shippingCountry: country,
             shippingAddress,
+            inventoryHold: holdLines.filter(l => l.quantity > 0),
             checkoutData: checkoutData || {},
             status: 'pending',
             statusHistory: [{ status: 'pending', timestamp: now }],
             createdAt: now,
         };
 
-        await saveGuestOrder(order);
+            await saveGuestOrder(order);
 
-        return NextResponse.json({ url: session.url, sessionId: session.id, orderId });
+            return NextResponse.json({ url: session.url, sessionId: session.id, orderId });
+        } catch (inner) {
+            // Roll back the reservation — the session/order never came to be.
+            await release(holdLines);
+            throw inner;
+        }
     } catch (error) {
         console.error('[Stripe Checkout] Error:', error);
         return NextResponse.json({ error: 'Failed to start checkout' }, { status: 500 });

--- a/src/app/api/orders/route.ts
+++ b/src/app/api/orders/route.ts
@@ -8,6 +8,7 @@ import { rateLimit, rateLimitResponse } from '../../../lib/rateLimit';
 import { PointsTransaction } from '../../../types/Points';
 import { validateCSRFToken } from '../../../lib/csrf';
 import { validateCartItems } from '../../../lib/productValidation';
+import { commitImmediate, restock, StockLine } from '../../../lib/inventory';
 import { mirrorOrder, mirrorUser } from '../../../lib/airtableMirror';
 import { sendEmail, buildOrderConfirmation, buildAdminNewOrder } from '../../../lib/email';
 
@@ -58,6 +59,8 @@ export async function POST(request: Request) {
         return rateLimitResponse();
     }
 
+    // Stock decremented for this attempt; restocked if the order then fails to save.
+    let committedStock: StockLine[] | null = null;
     try {
         const { items, pointsRequired, shippingCountry, shippingPointsCost, checkoutData, csrfToken, idempotencyKey } = await request.json() as {
             items: { id: string; name: string; price: string; quantity: number; variant_id?: string | number }[];
@@ -132,6 +135,25 @@ export async function POST(request: Request) {
                 balance: pointsBalance
             }, { status: 400 });
         }
+
+        // Decrement stock immediately — points orders settle in-request, so there's
+        // no reservation window. Fails closed before any points are deducted; if
+        // anything below throws, we release the units so they aren't leaked.
+        const stockLines: StockLine[] = validation.items!.map(i => ({ variantId: i.variantId, quantity: i.quantity }));
+        const stockResult = await commitImmediate(stockLines);
+        if (!stockResult.ok) {
+            const oversold = validation.items!.find(i => i.variantId === stockResult.variantId);
+            const name = oversold?.name || 'An item';
+            return NextResponse.json(
+                {
+                    error: stockResult.available > 0
+                        ? `Only ${stockResult.available} of ${name} left — please reduce the quantity.`
+                        : `${name} just sold out.`,
+                },
+                { status: 409 },
+            );
+        }
+        committedStock = stockLines;
 
         // Extract + validate the structured shipping address (if present in checkoutData).
         let shippingAddress: ShippingAddress | undefined;
@@ -238,6 +260,9 @@ export async function POST(request: Request) {
         });
     } catch (error) {
         console.error('[Orders API] Error creating order:', error);
+        // If we'd already decremented stock for this attempt, give it back so a
+        // failed save doesn't strand units. restock() is best-effort/no-throw.
+        if (committedStock) void restock(committedStock);
         return NextResponse.json({ error: 'Failed to create order' }, { status: 500 });
     }
 }

--- a/src/app/api/products/[id]/route.ts
+++ b/src/app/api/products/[id]/route.ts
@@ -4,6 +4,7 @@ import { getServerSession } from 'next-auth';
 import { authOptions } from '../../auth/[...nextauth]/route';
 import { requireAdminPermission } from '../../../../lib/adminAuth';
 import { resolveDualPrice } from '../../../../lib/variantPricing';
+import { getVariantStocks } from '../../../../lib/inventory';
 
 const redis = new Redis({
     url: process.env.UPSTASH_REDIS_REST_URL!,
@@ -12,7 +13,7 @@ const redis = new Redis({
 
 export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
     const productId = params.id;
-    
+
     try {
         const product = await redis.get<any>(`product:${productId}`);
 
@@ -41,6 +42,13 @@ export async function GET(req: NextRequest, { params }: { params: { id: string }
                 },
             })),
         };
+
+        // Enrich variants with live availability (null = untracked/unlimited).
+        const stocks = await getVariantStocks(result.sync_variants.map((v: any) => v.variant_id));
+        result.sync_variants = result.sync_variants.map((v: any) => ({
+            ...v,
+            available: stocks[v.variant_id]?.available ?? null,
+        }));
 
         return NextResponse.json({ result });
     } catch (error) {

--- a/src/app/api/products/route.ts
+++ b/src/app/api/products/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { Redis } from '@upstash/redis';
 import { resolveDualPrice } from '../../../lib/variantPricing';
+import { getVariantStocks } from '../../../lib/inventory';
 
 const redis = new Redis({
     url: process.env.UPSTASH_REDIS_REST_URL!,
@@ -10,30 +11,43 @@ const redis = new Redis({
 export async function GET() {
   try {
     const keys = await redis.keys('product:*');
-    const products: any[] = [];
-
+    const rawProducts: any[] = [];
     for (const key of keys) {
         const product = await redis.get<any>(key);
-        if (product) {
-            products.push({
-                id: product.id,
-                name: product.name,
-                thumbnail_url: product.thumbnail_url,
-                sync_variants: (product.variants || []).map((variant: any, idx: number) => ({
-                    id: variant.id || `${product.id}_var_${idx}`,
-                    variant_id: variant.variant_id || `${product.id}_var_${idx}`,
-                    name: variant.name,
-                    retail_price: (variant.price ?? 0).toString(),
-                    ...resolveDualPrice(variant),
-                    size: variant.size || 'One Size',
-                    color: variant.color || 'Default',
-                    product: {
-                        image: variant.image_url || product.image_url || product.thumbnail_url,
-                    },
-                })),
-            });
-        }
+        if (product) rawProducts.push(product);
     }
+
+    // Enrich variants with live availability in one batched stock read. `available`
+    // is null for untracked variants (unlimited) and a number when stock is tracked.
+    const variantIds = rawProducts.flatMap((p: any) =>
+        (p.variants || []).map((v: any, idx: number) => v.variant_id || v.id || `${p.id}_var_${idx}`),
+    );
+    const stocks = await getVariantStocks(variantIds);
+
+    const products = rawProducts.map((product: any) => ({
+        id: product.id,
+        name: product.name,
+        thumbnail_url: product.thumbnail_url,
+        category: product.category || null,
+        createdAt: product.createdAt || null,
+        sync_variants: (product.variants || []).map((variant: any, idx: number) => {
+            const variantId = variant.variant_id || variant.id || `${product.id}_var_${idx}`;
+            const available = stocks[variantId]?.available ?? null;
+            return {
+                id: variant.id || `${product.id}_var_${idx}`,
+                variant_id: variantId,
+                name: variant.name,
+                retail_price: (variant.price ?? 0).toString(),
+                ...resolveDualPrice(variant),
+                size: variant.size || 'One Size',
+                color: variant.color || 'Default',
+                available, // null = unlimited; number = units left
+                product: {
+                    image: variant.image_url || product.image_url || product.thumbnail_url,
+                },
+            };
+        }),
+    }));
 
     return NextResponse.json({ code: 200, result: products });
   } catch (error) {

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -4,6 +4,7 @@ import { getStripe } from '../../../../lib/stripe';
 import { getGuestOrder, getGuestOrderBySession, updateGuestOrder } from '../../../../lib/guestOrders';
 import { mirrorOrder } from '../../../../lib/airtableMirror';
 import { sendEmail, buildOrderConfirmation, buildAdminNewOrder } from '../../../../lib/email';
+import { commitReserved, release } from '../../../../lib/inventory';
 
 /**
  * Stripe webhook — the ONLY trusted signal that a guest order was paid. The
@@ -50,8 +51,13 @@ export async function POST(request: Request) {
                     break;
                 }
 
-                // Idempotent: ignore if already finalized.
+                // Idempotent: ignore if already finalized (also guards commit).
                 if (order.paymentStatus === 'paid') break;
+
+                // Convert the held reservation into a sale (decrements base stock).
+                if (order.inventoryHold && order.inventoryHold.length > 0) {
+                    await commitReserved(order.inventoryHold);
+                }
 
                 const email = order.guestEmail || session.customer_details?.email || undefined;
                 const updated = await updateGuestOrder(order.id, {
@@ -78,6 +84,10 @@ export async function POST(request: Request) {
                 const session = event.data.object as Stripe.Checkout.Session;
                 const order = await getGuestOrderBySession(session.id);
                 if (order && order.paymentStatus === 'unpaid') {
+                    // Free the held units — the guest never paid.
+                    if (order.inventoryHold && order.inventoryHold.length > 0) {
+                        await release(order.inventoryHold);
+                    }
                     await updateGuestOrder(order.id, { status: 'denied' });
                 }
                 break;

--- a/src/app/products/[id]/page.tsx
+++ b/src/app/products/[id]/page.tsx
@@ -48,8 +48,10 @@ const ProductPage = () => {
         fetchProduct();
     }, [productId]);
 
+    const isInStock = (v: Variant | null) => !v || v.available === undefined || v.available === null || v.available > 0;
+
     const handleAddToCart = () => {
-        if (product && selectedVariant && isAvailableOn(selectedVariant, pathway)) {
+        if (product && selectedVariant && isAvailableOn(selectedVariant, pathway) && isInStock(selectedVariant)) {
             const cartItem = {
                 id: product.id,
                 name: selectedVariant.name,
@@ -102,8 +104,11 @@ const ProductPage = () => {
     // Strict path separation: a variant is buyable only if it's priced for the
     // active pathway, and the product is only purchasable at all if at least one
     // variant is.
-    const selectedAvailable = !!selectedVariant && isAvailableOn(selectedVariant, pathway);
+    const selectedInStock = isInStock(selectedVariant);
+    const selectedAvailable = !!selectedVariant && isAvailableOn(selectedVariant, pathway) && selectedInStock;
     const anyVariantAvailable = variants.some((variant) => isAvailableOn(variant, pathway));
+    const selectedStock = selectedVariant?.available;
+    const selectedLow = typeof selectedStock === 'number' && selectedStock > 0 && selectedStock <= 5;
 
     return (
         <div
@@ -142,6 +147,11 @@ const ProductPage = () => {
                                 ) : (
                                     <p className="text-lg text-gray-400 font-medium">Not available</p>
                                 )}
+                                {selectedStock === 0 ? (
+                                    <p className="mt-2 inline-block px-3 py-1 rounded-full text-sm font-black bg-hackclub-dark text-white">Sold out</p>
+                                ) : selectedLow ? (
+                                    <p className="mt-2 inline-block px-3 py-1 rounded-full text-sm font-black bg-hackclub-orange text-white">Only {selectedStock} left</p>
+                                ) : null}
                             </div>
                         )}
 
@@ -167,6 +177,7 @@ const ProductPage = () => {
                                         <option key={`${variant.id || variant.variant_id}_${idx}`} value={variant.id || variant.variant_id}>
                                             {variant.size || 'Default'} / {variant.color || 'Default'}
                                             {getDisplayPrice(variant, pathway) ? ` - ${getDisplayPrice(variant, pathway)}` : ''}
+                                            {variant.available === 0 ? ' (sold out)' : ''}
                                         </option>
                                     ))}
                                 </select>
@@ -185,7 +196,7 @@ const ProductPage = () => {
                                 }
                                 onClick={handleAddToCart}
                             >
-                                {selectedAvailable ? 'Add to Cart' : 'Not available'}
+                                {selectedAvailable ? 'Add to Cart' : !selectedInStock ? 'Sold out' : 'Not available'}
                             </motion.button>
                         ) : (
                             <div className="rounded-2xl border-2 border-gray-200 bg-hackclub-smoke p-5 text-center">

--- a/src/app/shop/page.tsx
+++ b/src/app/shop/page.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import React, { useState, useEffect, useContext } from 'react';
+import React, { useState, useEffect, useContext, useMemo } from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
 import { motion } from 'framer-motion';
 import { CartContext } from '../../context/CartContext';
+import { CardSkeleton } from '../components/Skeleton';
 import { getCashPrice, getPointsPrice, getDisplayPrice, isAvailableOn } from '../../lib/paymentUtils';
 import { usePathway } from '../../lib/usePathway';
 
@@ -17,6 +18,7 @@ interface Variant {
     retail_price: string;
     price_cash?: number;
     price_points?: number;
+    available?: number | null; // null = unlimited; number = units left
     product: { image: string };
 }
 
@@ -24,8 +26,12 @@ interface Product {
     id: string | number;
     name: string;
     thumbnail_url: string;
+    category?: string | null;
+    createdAt?: string | null;
     sync_variants: Variant[];
 }
+
+type SortKey = 'featured' | 'price-asc' | 'price-desc' | 'newest' | 'name';
 
 const Shop = () => {
     const [products, setProducts] = useState<Product[]>([]);
@@ -40,14 +46,67 @@ const Shop = () => {
     const cartContext = useContext(CartContext);
     const { pathway, loading: pathwayLoading } = usePathway();
 
+    // Catalog controls.
+    const [query, setQuery] = useState('');
+    const [category, setCategory] = useState<string>('all');
+    const [sort, setSort] = useState<SortKey>('featured');
+
     // Strict path separation: while auth resolves, show everything; once
     // resolved, only show products with at least one variant the active
     // pathway can actually buy.
-    const visibleProducts = pathwayLoading
-        ? products
-        : products.filter((product) =>
-              (product.sync_variants || []).some((variant) => isAvailableOn(variant, pathway))
-          );
+    const pathwayProducts = useMemo(
+        () =>
+            pathwayLoading
+                ? products
+                : products.filter((product) =>
+                      (product.sync_variants || []).some((variant) => isAvailableOn(variant, pathway)),
+                  ),
+        [products, pathway, pathwayLoading],
+    );
+
+    // Distinct categories present in the pathway-visible catalog (for the chips).
+    const categories = useMemo(() => {
+        const set = new Set<string>();
+        for (const p of pathwayProducts) {
+            if (p.category && p.category.trim()) set.add(p.category.trim());
+        }
+        return Array.from(set).sort((a, b) => a.localeCompare(b));
+    }, [pathwayProducts]);
+
+    // The pathway-aware unit price used for sorting/searching.
+    const priceFor = (p: Product): number => {
+        const v = p.sync_variants?.[0];
+        if (!v) return 0;
+        return (pathway === 'student' ? getPointsPrice(v) : getCashPrice(v)) || 0;
+    };
+
+    // Search → category → sort, layered on top of the pathway filter.
+    const visibleProducts = useMemo(() => {
+        const q = query.trim().toLowerCase();
+        let list = pathwayProducts;
+        if (q) list = list.filter((p) => p.name.toLowerCase().includes(q) || (p.category || '').toLowerCase().includes(q));
+        if (category !== 'all') list = list.filter((p) => (p.category || '').trim() === category);
+
+        const sorted = [...list];
+        switch (sort) {
+            case 'price-asc':
+                sorted.sort((a, b) => priceFor(a) - priceFor(b));
+                break;
+            case 'price-desc':
+                sorted.sort((a, b) => priceFor(b) - priceFor(a));
+                break;
+            case 'name':
+                sorted.sort((a, b) => a.name.localeCompare(b.name));
+                break;
+            case 'newest':
+                sorted.sort((a, b) => new Date(b.createdAt || 0).getTime() - new Date(a.createdAt || 0).getTime());
+                break;
+            default:
+                break; // 'featured' = catalog order
+        }
+        return sorted;
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [pathwayProducts, query, category, sort, pathway]);
 
     useEffect(() => {
         const fetchProducts = async () => {
@@ -113,7 +172,7 @@ const Shop = () => {
                     upEvent.clientY >= rect.top - 100 &&
                     upEvent.clientY <= rect.bottom + 100;
 
-                if (isNearCart && product.sync_variants && product.sync_variants.length > 0 && isAvailableOn(product.sync_variants[0], pathway) && cartContext) {
+                if (isNearCart && product.sync_variants && product.sync_variants.length > 0 && isAvailableOn(product.sync_variants[0], pathway) && product.sync_variants[0].available !== 0 && cartContext) {
                     droppedOnCart = true;
                     const variant = product.sync_variants[0];
 
@@ -145,11 +204,11 @@ const Shop = () => {
     };
 
     return (
-        <motion.div 
+        <motion.div
             initial={{ opacity: 0 }}
-            animate={{ opacity: loading ? 0 : 1 }}
+            animate={{ opacity: 1 }}
             transition={{ duration: 0.3 }}
-            className="min-h-screen bg-white" 
+            className="min-h-screen bg-white"
             style={{
                 backgroundImage: `
                   linear-gradient(to right, #e0f2fe 1px, transparent 1px),
@@ -160,7 +219,7 @@ const Shop = () => {
         >
             
             <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
-                <div className="mb-12">
+                <div className="mb-8">
                     <h1 className="text-5xl sm:text-6xl font-black text-hackclub-dark mb-4">
                         Browse Merch
                     </h1>
@@ -168,17 +227,87 @@ const Shop = () => {
                         Stickers, shirts, and more cool stuff
                     </p>
                 </div>
-                
+
+                {/* Search + sort */}
+                <div className="flex flex-col sm:flex-row gap-3 mb-5">
+                    <div className="relative flex-1">
+                        <svg className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-hackclub-muted pointer-events-none" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+                        </svg>
+                        <input
+                            type="search"
+                            value={query}
+                            onChange={(e) => setQuery(e.target.value)}
+                            placeholder="Search merch…"
+                            aria-label="Search products"
+                            className="w-full pl-11 pr-4 py-3 rounded-full border-2 border-hackclub-smoke bg-white text-hackclub-dark font-medium focus:outline-none focus:border-hackclub-red transition-colors"
+                        />
+                    </div>
+                    <label className="sr-only" htmlFor="sort">Sort products</label>
+                    <select
+                        id="sort"
+                        value={sort}
+                        onChange={(e) => setSort(e.target.value as SortKey)}
+                        className="px-4 py-3 rounded-full border-2 border-hackclub-smoke bg-white text-hackclub-dark font-bold focus:outline-none focus:border-hackclub-red transition-colors"
+                    >
+                        <option value="featured">Featured</option>
+                        <option value="price-asc">Price: low to high</option>
+                        <option value="price-desc">Price: high to low</option>
+                        <option value="newest">Newest</option>
+                        <option value="name">Name (A–Z)</option>
+                    </select>
+                </div>
+
+                {/* Category chips */}
+                {categories.length > 0 && (
+                    <div className="flex flex-wrap gap-2 mb-10">
+                        <CategoryChip label="All" active={category === 'all'} onClick={() => setCategory('all')} />
+                        {categories.map((c) => (
+                            <CategoryChip key={c} label={c} active={category === c} onClick={() => setCategory(c)} />
+                        ))}
+                    </div>
+                )}
+
                 {error && (
                     <div className="text-center py-20">
                         <p className="text-hackclub-red text-lg font-bold">⚠️ {error}</p>
                     </div>
                 )}
 
+                {loading ? (
+                    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+                        {Array.from({ length: 8 }).map((_, i) => <CardSkeleton key={i} />)}
+                    </div>
+                ) : !error && visibleProducts.length === 0 ? (
+                    <div className="text-center py-20">
+                        <div className="w-16 h-16 bg-hackclub-smoke rounded-full flex items-center justify-center mx-auto mb-4">
+                            <svg className="w-8 h-8 text-hackclub-muted" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M16 11V7a4 4 0 00-8 0v4M5 9h14l1 12H4L5 9z" />
+                            </svg>
+                        </div>
+                        <p className="text-hackclub-dark font-black text-lg">
+                            {query || category !== 'all' ? 'No merch matches that' : 'No merch yet'}
+                        </p>
+                        <p className="text-hackclub-slate font-medium mt-1">
+                            {query || category !== 'all' ? 'Try a different search or category.' : 'Check back soon!'}
+                        </p>
+                        {(query || category !== 'all') && (
+                            <button
+                                type="button"
+                                onClick={() => { setQuery(''); setCategory('all'); }}
+                                className="mt-5 inline-block bg-hackclub-red hover:bg-hackclub-orange text-white font-bold px-6 py-2.5 rounded-full transition-colors"
+                            >
+                                Clear filters
+                            </button>
+                        )}
+                    </div>
+                ) : (
                 <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
                     {visibleProducts.map((product) => {
                       const firstVariant = product.sync_variants?.[0];
-                      const canBuy = firstVariant ? isAvailableOn(firstVariant, pathway) : false;
+                      const soldOut = firstVariant?.available === 0;
+                      const lowStock = typeof firstVariant?.available === 'number' && firstVariant.available > 0 && firstVariant.available <= 5;
+                      const canBuy = firstVariant ? isAvailableOn(firstVariant, pathway) && !soldOut : false;
                       return (
                         <motion.div
                             key={product.id}
@@ -197,9 +326,19 @@ const Shop = () => {
                                     src={product.thumbnail_url}
                                     alt={product.name}
                                     fill
-                                    className="object-contain p-6 group-hover:scale-105 transition-transform duration-300 pointer-events-none"
+                                    className={`object-contain p-6 group-hover:scale-105 transition-transform duration-300 pointer-events-none ${soldOut ? 'opacity-40 grayscale' : ''}`}
                                     draggable={false}
                                 />
+                                {soldOut && (
+                                    <span className="absolute top-3 left-3 px-2.5 py-1 rounded-full text-xs font-black bg-hackclub-dark text-white">
+                                        Sold out
+                                    </span>
+                                )}
+                                {!soldOut && lowStock && (
+                                    <span className="absolute top-3 left-3 px-2.5 py-1 rounded-full text-xs font-black bg-hackclub-orange text-white">
+                                        Only {firstVariant!.available} left
+                                    </span>
+                                )}
                             </div>
                             <div className="flex flex-col gap-2 p-5 bg-white">
                                 <Link href={`/products/${product.id}`} className="block">
@@ -250,7 +389,7 @@ const Shop = () => {
                                              e.currentTarget.blur();
                                          }}
                                     >
-                                        {canBuy ? 'Add to Cart' : 'Not available'}
+                                        {canBuy ? 'Add to Cart' : soldOut ? 'Sold out' : 'Not available'}
                                     </button>
                                 </div>
                             </div>
@@ -258,6 +397,7 @@ const Shop = () => {
                       );
                     })}
                 </div>
+                )}
 
                 {draggingProduct && (
                     <motion.div
@@ -291,5 +431,22 @@ const Shop = () => {
         </motion.div>
     );
 };
+
+function CategoryChip({ label, active, onClick }: { label: string; active: boolean; onClick: () => void }) {
+    return (
+        <button
+            type="button"
+            onClick={onClick}
+            aria-pressed={active}
+            className={`px-4 py-1.5 rounded-full text-sm font-bold border-2 transition-colors ${
+                active
+                    ? 'bg-hackclub-red text-white border-hackclub-red'
+                    : 'bg-white text-hackclub-slate border-hackclub-smoke hover:border-hackclub-red hover:text-hackclub-red'
+            }`}
+        >
+            {label}
+        </button>
+    );
+}
 
 export default Shop;

--- a/src/lib/inventory.ts
+++ b/src/lib/inventory.ts
@@ -1,0 +1,291 @@
+/**
+ * Inventory: stock tracking + reservation across both checkout pathways.
+ *
+ * Read `docs/INVENTORY.md` first — it explains the model. In short:
+ *   - Airtable `Products` is authoritative for the base stock number.
+ *   - Redis caches that base (`inventory:{variantId}`) and holds the live
+ *     `reserved` overlay (`inventory:{variantId}:reserved`) that Airtable never
+ *     sees.
+ *   - available = max(0, stock - reserved).
+ *   - A variant with NO stock number set is unlimited (preserves legacy behaviour).
+ *
+ * Everything here is fire-and-forget safe like `email.ts`/`airtableMirror.ts`:
+ * a Redis/Airtable hiccup degrades to "treat as available" rather than blocking a
+ * purchase. The ONE exception is `reserve()`/`commitImmediate()`, which fail
+ * CLOSED — they reject only when they can positively prove available < qty.
+ */
+
+import { Redis } from '@upstash/redis';
+
+const redis = new Redis({
+    url: process.env.UPSTASH_REDIS_REST_URL!,
+    token: process.env.UPSTASH_REDIS_REST_TOKEN!,
+});
+
+const stockKey = (variantId: string) => `inventory:${variantId}`;
+const reservedKey = (variantId: string) => `inventory:${variantId}:reserved`;
+
+/** A unit a checkout wants to hold/sell. */
+export interface StockLine {
+    variantId: string;
+    quantity: number;
+}
+
+interface StockCache {
+    stock: number;
+    syncedAt: string;
+}
+
+/**
+ * Current snapshot for a variant. `stock === null` means "untracked / unlimited".
+ */
+export interface VariantStock {
+    variantId: string;
+    stock: number | null;
+    reserved: number;
+    available: number | null; // null when untracked (unlimited)
+}
+
+async function readStock(variantId: string): Promise<number | null> {
+    try {
+        const cached = await redis.get<StockCache>(stockKey(variantId));
+        if (cached && typeof cached.stock === 'number') return cached.stock;
+        return null;
+    } catch {
+        return null;
+    }
+}
+
+async function readReserved(variantId: string): Promise<number> {
+    try {
+        const r = await redis.get<number>(reservedKey(variantId));
+        return typeof r === 'number' && r > 0 ? r : 0;
+    } catch {
+        return 0;
+    }
+}
+
+/** Snapshot of a single variant's stock/reserved/available. */
+export async function getVariantStock(variantId: string): Promise<VariantStock> {
+    const [stock, reserved] = await Promise.all([readStock(variantId), readReserved(variantId)]);
+    const available = stock === null ? null : Math.max(0, stock - reserved);
+    return { variantId, stock, reserved, available };
+}
+
+/** Snapshot for many variants at once (admin views, storefront enrichment). */
+export async function getVariantStocks(variantIds: string[]): Promise<Record<string, VariantStock>> {
+    const unique = Array.from(new Set(variantIds.filter(Boolean)));
+    const entries = await Promise.all(unique.map(getVariantStock));
+    const out: Record<string, VariantStock> = {};
+    for (const e of entries) out[e.variantId] = e;
+    return out;
+}
+
+/** Set/seed the cached base stock for a variant. Used by sync + admin adjust. */
+export async function setStock(variantId: string, stock: number | null): Promise<void> {
+    try {
+        if (stock === null || Number.isNaN(stock)) {
+            await redis.del(stockKey(variantId));
+            return;
+        }
+        const cache: StockCache = { stock: Math.max(0, Math.floor(stock)), syncedAt: new Date().toISOString() };
+        await redis.set(stockKey(variantId), cache);
+    } catch (err) {
+        console.error('[inventory] setStock failed:', err instanceof Error ? err.message : err);
+    }
+}
+
+/**
+ * Atomically try to reserve units for every line. Fails CLOSED: if any tracked
+ * line can't be satisfied, all reservations made in this call are rolled back and
+ * the conflicting line is returned. Untracked variants (no stock number) always
+ * succeed. Returns { ok: true } or { ok: false, variantId, available }.
+ *
+ * Race-safety: we incrby reserved first (atomic), then re-read stock and verify
+ * reserved <= stock. If we overshot, we decrby back. This is the standard
+ * optimistic-reserve pattern and is correct without Lua because incrby is atomic.
+ */
+export async function reserve(lines: StockLine[]): Promise<
+    { ok: true } | { ok: false; variantId: string; available: number }
+> {
+    const applied: StockLine[] = [];
+    for (const line of lines) {
+        if (line.quantity <= 0) continue;
+        const stock = await readStock(line.variantId);
+        if (stock === null) continue; // untracked → unlimited
+
+        let newReserved: number;
+        try {
+            newReserved = await redis.incrby(reservedKey(line.variantId), line.quantity);
+        } catch (err) {
+            // Can't reserve safely → fail closed for this tracked line.
+            console.error('[inventory] reserve incrby failed:', err instanceof Error ? err.message : err);
+            await rollback(applied);
+            return { ok: false, variantId: line.variantId, available: 0 };
+        }
+
+        if (newReserved > stock) {
+            // Oversold — undo this line and everything before it.
+            await safeDecr(line.variantId, line.quantity);
+            await rollback(applied);
+            const available = Math.max(0, stock - (newReserved - line.quantity));
+            return { ok: false, variantId: line.variantId, available };
+        }
+        applied.push(line);
+    }
+    return { ok: true };
+}
+
+/** Release a held reservation (Stripe session expired/cancelled). Best-effort. */
+export async function release(lines: StockLine[]): Promise<void> {
+    await rollback(lines);
+}
+
+/**
+ * Convert a held reservation into a sale: drop the reservation AND decrement the
+ * cached base stock. Best-effort; also writes the new number back to Airtable so
+ * the spreadsheet stays roughly current. Used by the Stripe webhook on payment.
+ */
+export async function commitReserved(lines: StockLine[], mirror?: (variantId: string, stock: number) => void): Promise<void> {
+    for (const line of lines) {
+        if (line.quantity <= 0) continue;
+        await safeDecr(line.variantId, line.quantity);
+        const stock = await readStock(line.variantId);
+        if (stock === null) continue;
+        const next = Math.max(0, stock - line.quantity);
+        await setStock(line.variantId, next);
+        if (mirror) mirror(line.variantId, next);
+    }
+}
+
+/**
+ * Decrement available stock immediately, with no reservation window. Used by the
+ * student/points path (settles in-request). Fails CLOSED: returns the conflicting
+ * line if a tracked variant lacks availability, decrementing nothing.
+ */
+export async function commitImmediate(
+    lines: StockLine[],
+    mirror?: (variantId: string, stock: number) => void,
+): Promise<{ ok: true } | { ok: false; variantId: string; available: number }> {
+    // First reserve (which does the atomic oversell check)…
+    const reserved = await reserve(lines);
+    if (!reserved.ok) return reserved;
+    // …then immediately commit those reservations into sold stock.
+    await commitReserved(lines, mirror);
+    return { ok: true };
+}
+
+/**
+ * Add units back to base stock — the inverse of a committed sale. Used to undo a
+ * `commitImmediate` when the order fails to save (student path), and available for
+ * admin refunds that should restore stock. Best-effort; untracked variants are
+ * left untouched.
+ */
+export async function restock(lines: StockLine[]): Promise<void> {
+    for (const line of lines) {
+        if (line.quantity <= 0) continue;
+        const stock = await readStock(line.variantId);
+        if (stock === null) continue; // untracked → nothing to restore
+        await setStock(line.variantId, stock + line.quantity);
+    }
+}
+
+async function rollback(lines: StockLine[]): Promise<void> {
+    for (const line of lines) {
+        if (line.quantity > 0) await safeDecr(line.variantId, line.quantity);
+    }
+}
+
+async function safeDecr(variantId: string, qty: number): Promise<void> {
+    try {
+        const next = await redis.decrby(reservedKey(variantId), qty);
+        // Never let reserved drift negative (e.g. double-release).
+        if (next < 0) await redis.set(reservedKey(variantId), 0);
+    } catch (err) {
+        console.error('[inventory] decr failed:', err instanceof Error ? err.message : err);
+    }
+}
+
+// ── Airtable read-sync (the new read direction) ──────────────────────────────
+//
+// Reads each product's variant stock from the Airtable Products table and seeds
+// the Redis base stock cache, WITHOUT touching the `reserved` overlay (see the
+// conflict rule in docs/INVENTORY.md). Cached behind a short TTL guard so the
+// storefront never hammers Airtable.
+
+const AIRTABLE_API_KEY = process.env.AIRTABLE_API_KEY;
+const AIRTABLE_BASE_ID = process.env.AIRTABLE_BASE_ID;
+const PRODUCTS_TABLE = process.env.AIRTABLE_PRODUCTS_TABLE || 'Products';
+const SYNC_GUARD_KEY = 'inventory:lastSync';
+const SYNC_MIN_INTERVAL_MS = 60_000; // don't re-sync Airtable more than once a minute
+
+export const isInventorySyncConfigured = () => Boolean(AIRTABLE_API_KEY && AIRTABLE_BASE_ID);
+
+interface AirtableVariant {
+    variant_id?: string;
+    id?: string;
+    stock?: number | string;
+}
+
+interface SyncResult {
+    ok: boolean;
+    synced: number;       // variants whose stock was seeded
+    skipped?: boolean;    // true if guarded by the min-interval
+    reason?: string;
+}
+
+/**
+ * Pull variant stock from Airtable → Redis base cache. `force` bypasses the
+ * min-interval guard (used by the admin "Sync now" button). Never throws.
+ */
+export async function syncInventoryFromAirtable(force = false): Promise<SyncResult> {
+    if (!isInventorySyncConfigured()) return { ok: false, synced: 0, reason: 'not_configured' };
+
+    try {
+        if (!force) {
+            const last = await redis.get<number>(SYNC_GUARD_KEY);
+            if (last && Date.now() - last < SYNC_MIN_INTERVAL_MS) {
+                return { ok: true, synced: 0, skipped: true };
+            }
+        }
+
+        let synced = 0;
+        let offset: string | undefined;
+        do {
+            const url = new URL(`https://api.airtable.com/v0/${AIRTABLE_BASE_ID}/${encodeURIComponent(PRODUCTS_TABLE)}`);
+            if (offset) url.searchParams.set('offset', offset);
+            const res = await fetch(url.toString(), {
+                headers: { Authorization: `Bearer ${AIRTABLE_API_KEY}` },
+            });
+            if (!res.ok) {
+                return { ok: false, synced, reason: `Airtable ${res.status}` };
+            }
+            const data = (await res.json()) as { records?: { fields?: Record<string, unknown> }[]; offset?: string };
+
+            for (const record of data.records || []) {
+                const raw = record.fields?.['Variants JSON'];
+                if (typeof raw !== 'string') continue;
+                let variants: AirtableVariant[];
+                try {
+                    variants = JSON.parse(raw);
+                } catch {
+                    continue;
+                }
+                for (const v of variants) {
+                    const vid = v.variant_id || v.id;
+                    if (!vid) continue;
+                    const stock = v.stock === undefined || v.stock === null || v.stock === '' ? null : Number(v.stock);
+                    await setStock(vid, stock === null || Number.isNaN(stock) ? null : stock);
+                    if (stock !== null && !Number.isNaN(stock)) synced++;
+                }
+            }
+            offset = data.offset;
+        } while (offset);
+
+        await redis.set(SYNC_GUARD_KEY, Date.now());
+        return { ok: true, synced };
+    } catch (err) {
+        console.error('[inventory] sync failed:', err instanceof Error ? err.message : err);
+        return { ok: false, synced: 0, reason: err instanceof Error ? err.message : 'sync failed' };
+    }
+}

--- a/src/lib/productValidation.ts
+++ b/src/lib/productValidation.ts
@@ -69,6 +69,7 @@ export interface VerifiedCartItem {
     pricePoints?: number;   // verified per-unit points price (student path)
     quantity: number;
     thumbnail_url?: string;
+    variantId: string;      // canonical variant id, for stock reservation
 }
 
 /**
@@ -141,6 +142,7 @@ export async function validateCartItems(items: CartItemForValidation[]): Promise
             pricePoints: price_points,
             quantity: item.quantity,
             thumbnail_url: variant.image_url || product.image_url || product.thumbnail_url,
+            variantId: String(variant.variant_id || variant.id),
         });
     }
 

--- a/src/types/Product.tsx
+++ b/src/types/Product.tsx
@@ -7,6 +7,7 @@ export interface Variant {
     // price_cash (USD) → adult/Stripe path; price_points → student path.
     price_cash?: number;
     price_points?: number;
+    available?: number | null; // null = unlimited; number = units left
     size: string;
     color: string;
     product: {


### PR DESCRIPTION
**Stacked PR 4 of 4** — base `track3-catalog` (#10). Review/merge last.

## What
- **`/admin/orders`**: free-text search (order #, email, user, item, tracking), status + pathway filters, pagination, and **CSV export** of the filtered set.
- **Audit log**: records refunds, point grants/deductions, order status changes, shipping, and stock edits to a capped Redis list. New `/admin/audit` page + `/api/admin/audit` (gated on `canViewStats`); `recordAudit` wired into the order, points, shipping, and inventory routes. Dashboard gains an Audit Log card.
- **`/admin/stats`**: cash-revenue vs points-spent split, a daily revenue **bar chart** (inline SVG, no chart dependency, CSP-safe), and **low-stock + abandoned-session** operational cards. Stats API extended accordingly.
- Adds `SHOP_UPGRADE_PROMPT.md` — the grounded spec for the whole 4-track program.

## Verify
`tsc`, `build`, `lint` clean on the full tree (this is the stack tip = complete working tree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)