### PR TITLE
Admin power: order search/CSV, audit log, richer stats

### DIFF
--- a/SHOP_UPGRADE_PROMPT.md
+++ b/SHOP_UPGRADE_PROMPT.md
@@ -1,0 +1,261 @@
+# Hack Club Shop — Upgrade & Improvement Spec
+
+> A grounded, end-to-end improvement prompt for the Hack Club Shop. Written against the
+> actual codebase (Next.js 13 App Router · TypeScript · Tailwind · Upstash Redis · Stripe ·
+> NextAuth/Hack Club OAuth · Airtable mirror · Vercel Blob). Scope spans **admin**,
+> **catalog**, **inventory (Airtable-backed)**, and **customer experience** for both the
+> **adult/guest (Stripe)** and **hack-clubber/student (points)** pathways.
+
+---
+
+## 0. Context the implementer must hold
+
+The shop forks into two pathways purely off auth state (`src/lib/usePathway.ts`):
+
+- **`student`** — logged in via Hack Club OAuth, pays in **points**, orders go through
+  `POST /api/orders` (immediate points deduction, order created `pending`→`approved`).
+- **`guest`** — logged out, pays **real USD** via **Stripe Checkout**, order created
+  `unpaid` and only confirmed by the `checkout.session.completed` webhook (the success
+  redirect is never trusted as proof of payment).
+
+Data lives in **Upstash Redis** as the source of truth. **Airtable is a fire-and-forget,
+write-only mirror** (`src/lib/airtableMirror.ts`) for staff visibility — the app does *not*
+currently read catalog/inventory back from it (only Projects reads from Airtable).
+
+Dual pricing per variant (`src/types/Admin.ts`): a variant is buyable on a pathway **iff**
+its price for that pathway is set — `price_cash` (USD) → guest, `price_points` → student.
+
+**Non-negotiable invariants** (do not regress these):
+1. **All prices are re-verified server-side** against Redis on every checkout. Client prices
+   are never trusted.
+2. **Stripe is webhook-confirmed only.** Never mark a guest order paid from the redirect.
+3. **Airtable failures must never break a purchase** — keep all mirror calls fire-and-forget/no-throw.
+4. **Idempotency + rate limits** on order creation stay intact.
+5. **Cart clears only on confirmed success**, never on a cancelled/abandoned payment.
+6. **Permission gates** (`AdminPermissions` in `src/types/Admin.ts`) are enforced on both the
+   page and the API route for every admin action.
+
+---
+
+## 1. Goals (what "really good" means here)
+
+Ship a cohesive set of upgrades across four tracks. Each item below is independently
+shippable — prefer small, verifiable PRs over one mega-change. Preserve the Hack Club
+visual identity (Phantom Sans, the brand palette, draggable-sticker playfulness) while
+raising polish, accessibility, and operational power.
+
+---
+
+## 2. INVENTORY — Airtable-backed stock (highest-leverage new capability)
+
+Today `ProductVariant.stock` is captured in the admin form, stored in Redis, and **never
+enforced or surfaced**. Make inventory real, with **Airtable as the system of record for
+stock levels** so non-engineer staff can manage it in a spreadsheet.
+
+**Design:**
+- Introduce an inventory sync that **reads** stock from the Airtable `Products`/variants
+  table into Redis on a cadence (cron/route) and on-demand, caching in Redis
+  (`inventory:{variantId}` with a short TTL) so the storefront stays fast and Airtable
+  rate limits aren't hit on every page load. This is a *new* read direction — build it
+  alongside the existing write-only mirror, don't break the mirror.
+- Decide and document the **conflict rule**: Airtable is authoritative for stock; the app
+  decrements a Redis "reserved/sold" counter on order, and the sync reconciles. Write this
+  rule down in `docs/`.
+- **Enforce stock at checkout** in BOTH paths:
+  - `POST /api/orders` (student) and `POST /api/checkout/stripe` (guest) must re-check
+    available stock server-side and reject oversells with a clear 409-style error.
+  - For Stripe, decrement reserved stock when the session is created and **release the
+    reservation if the session expires/cancels** (handle `checkout.session.expired`).
+    Only convert reserved→sold on `checkout.session.completed`.
+- **Surface stock in the UI**: "Only N left", "Out of stock" (disable Add to Cart),
+  low-stock badges on `ProductCard` and the product detail page. Respect pathway — a
+  variant with no price for the current pathway is already hidden; stock is an additional gate.
+- **Admin inventory view**: a `/admin/inventory` page (gated by `canManageProducts`) showing
+  every variant, current stock, reserved, sold, and a low-stock filter. Link out to the
+  Airtable row for editing, plus an in-app quick-adjust that writes back through the mirror.
+- **Backfill/repair**: extend or add to `/api/admin/airtable-backfill` so stock can be
+  initialized from current Redis state without data loss.
+
+**Acceptance:** A variant set to stock 0 in Airtable cannot be purchased on either pathway;
+an abandoned Stripe session releases its reservation; the admin inventory page reflects
+reality within one sync cycle.
+
+---
+
+## 3. CATALOG — discoverability & merchandising
+
+The `category` field exists on `Product` but is unused; there is **no search, filter, sort,
+or empty state** on `/shop`.
+
+- **Search** (client-side over the fetched catalog is fine to start): name + description match.
+- **Categories**: make `category` real — filter chips/tabs on `/shop`, category management in
+  the admin product form. Backfill existing products to a default category.
+- **Sort**: price (pathway-aware), newest, name.
+- **Empty & loading states**: use the existing `Skeleton`/`CardSkeleton` for the initial
+  product fetch (today the grid renders empty while loading), and a friendly empty state
+  when filters match nothing.
+- **Product detail upgrades**: image gallery (multiple images per product/variant), variant
+  selection that previews the matching image, richer description (markdown?), related/"more
+  from this category" rail.
+- **Variant selector polish**: replace the bare `<select>` with an accessible, on-brand
+  control; show color swatches and size pills instead of dropdown text where applicable.
+- **Featured / new / sold-out** merchandising flags controllable from admin.
+
+**Acceptance:** A shopper can search "sticker", filter to a category, sort by price, and see
+correct pathway-aware prices and stock — on mobile and desktop.
+
+---
+
+## 4. ADMIN — operational power
+
+Build on the existing dashboard, orders, products, users, coupons, admins, stats, projects.
+
+- **Orders**: search/filter (by status, pathway, email/user, date range), pagination,
+  CSV export, and a fulfillment workflow that captures **tracking number + carrier** and
+  includes it in the "shipped" status email. Bulk actions (approve/fulfill multiple).
+- **Stats**: richer analytics — revenue over time (chart), points spent vs. cash revenue
+  split, conversion (carts → orders), top products already exists; add low-stock alerts and
+  abandoned/expired Stripe sessions. Keep test orders excluded.
+- **Products**: category + merchandising flags (see §3), bulk price edit, duplicate-product
+  action, and inline image management for the new gallery.
+- **Inventory**: the `/admin/inventory` page from §2.
+- **Audit log**: record who did what (refunds, point grants, status changes) — a Redis
+  append log surfaced in admin, since these are real money/points actions.
+- **Coupons**: usage analytics (how many redeemed, revenue impact) and per-pathway coupon
+  applicability if not already supported.
+
+**Acceptance:** A store manager can find an order by customer email, mark it shipped with a
+tracking number (customer gets an email with the link), and export the month's orders to CSV.
+
+---
+
+## 5. CUSTOMER EXPERIENCE — both pathways
+
+- **Accessibility pass (do this early, it's currently weak)**: ARIA labels on icon buttons
+  (cart, user, menu), `sr-only` text, focus management for the cart drawer and modals,
+  keyboard operability, visible focus rings, and color-contrast checks against the brand
+  palette. Target WCAG 2.1 AA.
+- **Mobile polish**: tighten the `/checkout` form on small screens (currently cramped),
+  ensure the country dropdown and address fields don't overflow, and give drag-to-cart a
+  mobile-friendly equivalent (it's desktop-only today).
+- **Checkout resilience**: loading spinner on the Stripe redirect button, a retry path on
+  checkout errors, and clearer messaging when email isn't configured (don't fail silently).
+- **Order history & tracking** (`/orders`, students; and a guest-accessible equivalent):
+  show the tracking number/carrier link once fulfilled, an empty state, and a **reorder**
+  button that repopulates the cart.
+- **Guest order lookup**: since guests have no account, add an order-status lookup by
+  email + order id (linked from the confirmation email) so guests can check status.
+- **Cart cross-device for students**: optionally sync the logged-in student cart to Redis so
+  it follows them across devices (localStorage stays the guest fallback). Keep the
+  clear-on-confirmed-success-only invariant.
+- **Thank-you page**: surface what happens next per pathway, and for guests keep the
+  webhook-confirmed status polling but add a graceful "still processing" state.
+
+**Acceptance:** A screen-reader user can complete a guest checkout; a student can reorder a
+past order in two clicks; a guest can look up their order status from the email.
+
+---
+
+## 6. Cross-cutting / engineering quality
+
+- **Tests**: there is currently **no test infrastructure**. Add a lightweight setup (Vitest
+  recommended for this stack) and cover the highest-risk logic first: server-side price
+  re-verification, stock enforcement/reservation/release, pathway filtering, coupon math,
+  and the Stripe webhook state machine. Add an `npm test` script.
+- **Types**: retire the legacy `ProductVariant.price` field cleanly once dual-pricing is
+  fully relied upon, or document why it stays.
+- **Docs**: update the stale `README.md` (says "COMING SOON"), and add `docs/` entries for
+  the inventory sync model and the Airtable schema additions.
+- **Error/observability**: make email-send failures visible to admins (they're silent
+  no-ops today when unconfigured — fine for dev, but log/surface in prod).
+
+---
+
+## 7. How to work
+
+1. **Plan first.** Propose an ordered backlog of small PRs across the four tracks; get the
+   ordering confirmed before large changes. Recommended first slice: accessibility +
+   catalog search/empty-states (low risk, high visible value), then the inventory system
+   (highest leverage, most care needed around the Stripe reservation lifecycle).
+2. **Respect the invariants in §0** on every change. When a change touches checkout or
+   Stripe, call out explicitly how the invariant is preserved.
+3. **Pathway-aware by default.** Every customer-facing change must be correct for both
+   `student` and `guest`. Every price must be re-derived server-side.
+4. **Keep Airtable safe.** New read sync must be cached and rate-limit-aware; all writes
+   stay fire-and-forget.
+5. **Ship verifiable increments.** Each PR: what changed, which acceptance criteria it meets,
+   how to test it, and confirmation the build (`npm run build`) and lint pass. Add tests for
+   new server logic.
+6. **Don't regress the brand.** Phantom Sans, the Hack Club palette, the playful stickers and
+   animations stay. Polish, don't sterilize.
+
+---
+
+## 7a. Pirate Ship / EasyPost shipping (shipped in the customer-flow track)
+
+Pirate Ship has no public API — it runs on **EasyPost**, so the integration talks
+to EasyPost for rates, labels, and tracking. It is config-gated and degrades to
+manual tracking entry when unconfigured, mirroring the email/Airtable pattern.
+
+**New env vars** (all optional; absence → manual-tracking-only fallback):
+- `EASYPOST_API_KEY` — EasyPost key (`EZTK…` test / `EZAK…` prod).
+- `SHIP_FROM_NAME`, `SHIP_FROM_COMPANY`, `SHIP_FROM_STREET1`, `SHIP_FROM_STREET2`,
+  `SHIP_FROM_CITY`, `SHIP_FROM_STATE`, `SHIP_FROM_ZIP`, `SHIP_FROM_COUNTRY`,
+  `SHIP_FROM_PHONE` — origin address postage ships from.
+- `NEXT_PUBLIC_API_URL` / `NEXTAUTH_URL` — used to build the guest tracking link
+  in confirmation emails (already present).
+
+**New Airtable `Orders` columns** (add manually for staff visibility): `Carrier`,
+`Tracking Number`, `Tracking URL`.
+
+**Files added:** `src/lib/shipping.ts`, `src/lib/orderStore.ts`,
+`src/app/api/admin/orders/[id]/shipping/route.ts`, `src/app/admin/orders/ShippingPanel.tsx`,
+`src/app/api/orders/lookup/route.ts`, `src/app/orders/track/page.tsx`,
+`src/app/api/cart/route.ts`. New `Order.shipment` field in `src/types/Order.ts`.
+
+## 7b. Inventory — Airtable-backed stock (shipped)
+
+Full model documented in `docs/INVENTORY.md`. Summary: Airtable `Products` is
+authoritative for the base stock number; Redis caches it (`inventory:{variantId}`)
+and holds the live `reserved` overlay (`inventory:{variantId}:reserved`).
+`available = max(0, stock - reserved)`. A variant with no stock number is
+unlimited (no migration needed). Guest/Stripe orders reserve → commit on paid /
+release on expired; student/points orders commit immediately (no reservation
+window). Both checkout paths fail closed on a proven oversell (409).
+
+**New Airtable `Products` column:** `Total Stock` (roll-up; per-variant stock
+lives inside `Variants JSON`, which the sync reads).
+
+**Files added:** `src/lib/inventory.ts`, `src/app/api/admin/inventory/route.ts`,
+`src/app/api/admin/inventory/sync/route.ts`, `src/app/admin/inventory/page.tsx`,
+`docs/INVENTORY.md`. New `Order.inventoryHold`; `available` on the product APIs.
+Enforcement wired into `checkout/stripe`, `webhooks/stripe`, `orders`, and admin
+refund. Backfill seeds inventory from existing Redis stock.
+
+## 7c. Catalog — discoverability (shipped)
+
+`/shop` now has **search** (name + category), **category chips** (driven by the
+real `Product.category`, which the admin form already manages), a **sort** control
+(featured / price asc·desc — pathway-aware / newest / name), **CardSkeleton**
+loading state for the initial fetch, and a **friendly empty state** with a clear-
+filters action. All filtering layers on top of the existing pathway filter, so it
+stays correct for both `student` and `guest`. `/api/products` now returns
+`category` and `createdAt` per product.
+
+## 8. Key files reference
+
+| Concern | Files |
+|---|---|
+| Pathway fork | `src/lib/usePathway.ts`, `src/lib/paymentUtils.ts` |
+| Types | `src/types/Order.ts`, `src/types/Admin.ts`, `src/types/Points.ts` |
+| Catalog API | `src/app/api/products/route.ts`, `src/app/api/products/[id]/route.ts` |
+| Student orders | `src/app/api/orders/route.ts`, `src/context/PointsContext.tsx` |
+| Guest/Stripe | `src/lib/stripe.ts`, `src/app/api/checkout/stripe/route.ts`, `src/app/api/checkout/stripe/status/route.ts`, `src/app/api/webhooks/stripe/route.ts`, `src/lib/guestOrders.ts` |
+| Airtable | `src/lib/airtableMirror.ts`, `src/lib/airtable.ts`, `src/app/api/admin/airtable-backfill/route.ts` |
+| Admin pages | `src/app/admin/**` (`page.tsx`, `orders/`, `products/`, `users/`, `coupons/`, `admins/`, `stats/`, `projects/`) |
+| Admin auth | `src/lib/adminAuth.ts`, `src/app/api/admin/me/route.ts` |
+| Storefront UI | `src/app/shop/page.tsx`, `src/app/products/[id]/page.tsx`, `src/app/checkout/page.tsx`, `src/app/thank-you/page.tsx`, `src/app/orders/page.tsx` |
+| Components | `src/app/components/Navigation.tsx`, `CartModal.tsx`, `ProductCard.tsx`, `Skeleton.tsx` |
+| Cart/state | `src/context/CartContext.tsx` |
+| Email | `src/lib/email.ts` |
+| Validation | `src/lib/productValidation.ts`, `src/lib/address.ts` |

--- a/src/app/admin/audit/page.tsx
+++ b/src/app/admin/audit/page.tsx
@@ -1,0 +1,117 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useSession, signIn } from 'next-auth/react';
+import Link from 'next/link';
+import { motion } from 'framer-motion';
+
+interface AuditEntry {
+    id: string;
+    action: string;
+    actorId: string;
+    actorEmail?: string;
+    target?: string;
+    summary: string;
+    timestamp: string;
+}
+
+const ACTION_COLOR: Record<string, string> = {
+    'order.approve': 'bg-blue-100 text-blue-800',
+    'order.deny': 'bg-red-100 text-red-800',
+    'order.fulfill': 'bg-green-100 text-green-800',
+    'order.refund': 'bg-orange-100 text-orange-800',
+    'order.ship': 'bg-cyan-100 text-cyan-800',
+    'order.mark-test': 'bg-gray-100 text-gray-600',
+    'order.unmark-test': 'bg-gray-100 text-gray-600',
+    'points.grant': 'bg-green-100 text-green-800',
+    'points.deduct': 'bg-red-100 text-red-800',
+    'inventory.adjust': 'bg-purple-100 text-purple-800',
+};
+
+export default function AuditAdmin() {
+    const { data: session, status } = useSession();
+    const [entries, setEntries] = useState<AuditEntry[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        if (status === 'unauthenticated') signIn('hackclub', { callbackUrl: '/admin/audit' });
+    }, [status]);
+
+    useEffect(() => {
+        if (!session) return;
+        (async () => {
+            try {
+                const res = await fetch('/api/admin/audit?limit=200');
+                if (!res.ok) {
+                    setError(res.status === 403 ? 'You don’t have permission to view the audit log.' : 'Failed to load audit log');
+                    return;
+                }
+                const data = await res.json();
+                setEntries(data.entries || []);
+            } catch {
+                setError('Failed to load audit log');
+            } finally {
+                setLoading(false);
+            }
+        })();
+    }, [session]);
+
+    if (status === 'loading' || (session && loading)) {
+        return (
+            <div className="min-h-screen flex items-center justify-center bg-hackclub-smoke">
+                <div className="text-hackclub-dark font-bold">Loading…</div>
+            </div>
+        );
+    }
+    if (!session) return null;
+
+    return (
+        <div className="min-h-screen bg-white text-hackclub-dark"
+            style={{
+                backgroundImage: 'linear-gradient(to right, #e0f2fe 1px, transparent 1px), linear-gradient(to bottom, #e0f2fe 1px, transparent 1px)',
+                backgroundSize: '30px 30px',
+            }}
+        >
+            <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+                <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.4 }}>
+                    <Link href="/admin" className="text-hackclub-slate hover:text-hackclub-dark mb-2 inline-block font-medium">
+                        ← Back to Dashboard
+                    </Link>
+                    <h1 className="text-5xl sm:text-6xl font-black text-hackclub-dark mb-2">Audit Log</h1>
+                    <p className="text-lg text-hackclub-slate font-medium mb-8">
+                        Who did what — refunds, point grants, status changes, shipping, and stock edits.
+                    </p>
+
+                    {error && (
+                        <div className="mb-4 p-4 bg-hackclub-red/10 border-2 border-hackclub-red rounded-xl">
+                            <p className="text-hackclub-red font-bold">{error}</p>
+                        </div>
+                    )}
+
+                    {entries.length === 0 && !error ? (
+                        <div className="text-center py-16 bg-white rounded-2xl shadow-lg border-2 border-hackclub-smoke">
+                            <p className="text-hackclub-muted font-bold">No actions recorded yet.</p>
+                        </div>
+                    ) : (
+                        <div className="bg-white rounded-2xl shadow-lg border-2 border-hackclub-smoke divide-y divide-hackclub-smoke">
+                            {entries.map((e) => (
+                                <div key={e.id} className="px-5 py-4 flex items-start gap-3">
+                                    <span className={`shrink-0 px-2.5 py-1 rounded-full text-xs font-bold ${ACTION_COLOR[e.action] || 'bg-gray-100 text-gray-700'}`}>
+                                        {e.action}
+                                    </span>
+                                    <div className="flex-1 min-w-0">
+                                        <p className="font-medium text-hackclub-dark">{e.summary}</p>
+                                        <p className="text-xs text-hackclub-muted mt-0.5">
+                                            {e.actorEmail || e.actorId} · {new Date(e.timestamp).toLocaleString()}
+                                        </p>
+                                    </div>
+                                </div>
+                            ))}
+                        </div>
+                    )}
+                </motion.div>
+            </div>
+        </div>
+    );
+}

--- a/src/app/admin/orders/page.tsx
+++ b/src/app/admin/orders/page.tsx
@@ -1,10 +1,15 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { useSession, signIn } from 'next-auth/react';
 import Link from 'next/link';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Order } from '../../../types/Order';
+import ShippingPanel from './ShippingPanel';
+
+const PAGE_SIZE = 25;
+type StatusFilter = 'all' | Order['status'];
+type PathwayFilter = 'all' | 'student' | 'guest';
 
 export default function OrdersAdmin() {
     const { data: session, status } = useSession();
@@ -14,6 +19,11 @@ export default function OrdersAdmin() {
     const [selectedOrder, setSelectedOrder] = useState<Order | null>(null);
     const [actingOrderId, setActingOrderId] = useState<string | null>(null);
     const [showTest, setShowTest] = useState(false);
+    // Search / filter / pagination.
+    const [query, setQuery] = useState('');
+    const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
+    const [pathwayFilter, setPathwayFilter] = useState<PathwayFilter>('all');
+    const [page, setPage] = useState(1);
 
     useEffect(() => {
         if (status === 'unauthenticated') {
@@ -100,6 +110,24 @@ export default function OrdersAdmin() {
         }
     };
 
+    // Filter pipeline: test toggle → status → pathway → free-text search.
+    // Computed before any early return so hook order stays stable.
+    const filteredOrders = useMemo(() => {
+        const orderSearchText = (o: Order) =>
+            [o.id, o.guestEmail, o.userId, ...o.items.map((i) => i.name), o.shipment?.trackingNumber]
+                .filter(Boolean)
+                .join(' ')
+                .toLowerCase();
+        const q = query.trim().toLowerCase();
+        return orders.filter((o) => {
+            if (!showTest && o.isTest) return false;
+            if (statusFilter !== 'all' && o.status !== statusFilter) return false;
+            if (pathwayFilter !== 'all' && o.pathway !== pathwayFilter) return false;
+            if (q && !orderSearchText(o).includes(q)) return false;
+            return true;
+        });
+    }, [orders, showTest, statusFilter, pathwayFilter, query]);
+
     if (status === 'loading' || (session && loading)) {
         return (
             <div className="min-h-screen flex items-center justify-center bg-hackclub-smoke">
@@ -108,7 +136,40 @@ export default function OrdersAdmin() {
         );
     }
 
-    const visibleOrders = showTest ? orders : orders.filter((o) => !o.isTest);
+    const totalPages = Math.max(1, Math.ceil(filteredOrders.length / PAGE_SIZE));
+    const clampedPage = Math.min(page, totalPages);
+    const visibleOrders = filteredOrders.slice((clampedPage - 1) * PAGE_SIZE, clampedPage * PAGE_SIZE);
+
+    const exportCsv = () => {
+        const headers = ['Order ID', 'Pathway', 'Status', 'Payment', 'Buyer', 'Items', 'Total (USD)', 'Points', 'Tracking', 'Created'];
+        const rows = filteredOrders.map((o) => [
+            o.id,
+            o.pathway,
+            o.status,
+            o.paymentStatus || '',
+            o.pathway === 'guest' ? o.guestEmail || '' : o.userId,
+            o.items.map((i) => `${i.quantity}x ${i.name}`).join('; '),
+            o.totalAmount.toFixed(2),
+            o.pointsSpent || 0,
+            o.shipment?.trackingNumber || '',
+            new Date(o.createdAt).toISOString(),
+        ]);
+        const esc = (v: unknown) => {
+            let s = String(v);
+            // Neutralize spreadsheet formula injection: a leading =,+,-,@ is treated
+            // as a formula by Excel/Sheets. Prefix with an apostrophe to force text.
+            if (/^[=+\-@]/.test(s)) s = `'${s}`;
+            return `"${s.replace(/"/g, '""')}"`;
+        };
+        const csv = [headers, ...rows].map((r) => r.map(esc).join(',')).join('\n');
+        const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = `orders-${new Date().toISOString().slice(0, 10)}.csv`;
+        a.click();
+        URL.revokeObjectURL(url);
+    };
 
     return (
         <div className="min-h-screen bg-white text-hackclub-dark"
@@ -136,16 +197,67 @@ export default function OrdersAdmin() {
                         View and manage all orders
                     </p>
 
-                    <div className="mb-12">
+                    {/* Search + filters + export */}
+                    <div className="flex flex-col lg:flex-row gap-3 mb-4">
+                        <div className="relative flex-1">
+                            <svg className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-hackclub-muted pointer-events-none" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+                            </svg>
+                            <input
+                                type="search"
+                                value={query}
+                                onChange={(e) => { setQuery(e.target.value); setPage(1); }}
+                                placeholder="Search by order #, email, user, item, tracking…"
+                                aria-label="Search orders"
+                                className="w-full pl-11 pr-4 py-2.5 rounded-full border-2 border-hackclub-smoke bg-white text-hackclub-dark font-medium focus:outline-none focus:border-hackclub-red transition-colors"
+                            />
+                        </div>
+                        <select
+                            value={statusFilter}
+                            onChange={(e) => { setStatusFilter(e.target.value as StatusFilter); setPage(1); }}
+                            aria-label="Filter by status"
+                            className="px-4 py-2.5 rounded-full border-2 border-hackclub-smoke bg-white text-hackclub-dark font-bold focus:outline-none focus:border-hackclub-red"
+                        >
+                            <option value="all">All statuses</option>
+                            <option value="pending">Pending</option>
+                            <option value="approved">Approved</option>
+                            <option value="fulfilled">Fulfilled</option>
+                            <option value="denied">Denied</option>
+                            <option value="refunded">Refunded</option>
+                        </select>
+                        <select
+                            value={pathwayFilter}
+                            onChange={(e) => { setPathwayFilter(e.target.value as PathwayFilter); setPage(1); }}
+                            aria-label="Filter by pathway"
+                            className="px-4 py-2.5 rounded-full border-2 border-hackclub-smoke bg-white text-hackclub-dark font-bold focus:outline-none focus:border-hackclub-red"
+                        >
+                            <option value="all">All pathways</option>
+                            <option value="student">Points</option>
+                            <option value="guest">Card</option>
+                        </select>
                         <button
                             type="button"
-                            onClick={() => setShowTest((prev) => !prev)}
+                            onClick={exportCsv}
+                            disabled={filteredOrders.length === 0}
+                            className="px-5 py-2.5 rounded-full text-sm font-bold bg-hackclub-blue hover:bg-blue-600 text-white transition-colors disabled:opacity-40"
+                        >
+                            Export CSV
+                        </button>
+                    </div>
+
+                    <div className="flex items-center justify-between mb-8">
+                        <button
+                            type="button"
+                            onClick={() => { setShowTest((prev) => !prev); setPage(1); }}
                             className={`inline-flex items-center gap-2 px-4 py-2 rounded-full text-sm font-bold border-2 transition-colors ${showTest ? 'bg-hackclub-dark text-white border-hackclub-dark' : 'bg-white text-hackclub-slate border-hackclub-smoke hover:border-hackclub-slate'}`}
                             aria-pressed={showTest}
                         >
                             <span className={`w-2 h-2 rounded-full ${showTest ? 'bg-hackclub-green' : 'bg-hackclub-muted'}`} />
                             Show test orders
                         </button>
+                        <p className="text-sm text-hackclub-muted font-bold">
+                            {filteredOrders.length} order{filteredOrders.length === 1 ? '' : 's'}
+                        </p>
                     </div>
 
                     {error && (
@@ -231,7 +343,7 @@ export default function OrdersAdmin() {
                                                 actions.push({ action: 'approve', label: 'Approve', className: 'bg-hackclub-green hover:bg-green-600' });
                                                 actions.push({ action: 'deny', label: 'Deny', className: 'bg-hackclub-red hover:bg-red-600' });
                                             } else if (order.status === 'approved') {
-                                                actions.push({ action: 'fulfill', label: 'Fulfill', className: 'bg-hackclub-blue hover:bg-blue-600' });
+                                                // Fulfillment now goes through the shipping panel (below); keep refund here.
                                                 actions.push({ action: 'refund', label: refundLabel, className: 'bg-hackclub-red hover:bg-red-600' });
                                             } else if (order.status === 'fulfilled') {
                                                 actions.push({ action: 'refund', label: refundLabel, className: 'bg-hackclub-red hover:bg-red-600' });
@@ -239,9 +351,16 @@ export default function OrdersAdmin() {
 
                                             const testAction: 'mark-test' | 'unmark-test' = order.isTest ? 'unmark-test' : 'mark-test';
                                             const testLabel = order.isTest ? 'Untest' : 'Mark test';
+                                            const applyUpdate = (updated: Order) => {
+                                                setOrders((prev) => prev.map((o) => (o.id === updated.id ? updated : o)));
+                                                setSelectedOrder((prev) => (prev && prev.id === updated.id ? updated : prev));
+                                            };
 
                                             return (
                                                 <div className="mt-4 flex flex-wrap gap-2">
+                                                    {order.status === 'approved' && (
+                                                        <ShippingPanel order={order} onShipped={applyUpdate} onError={setError} />
+                                                    )}
                                                     {actions.map(({ action, label, className }) => (
                                                         <button
                                                             key={action}
@@ -264,6 +383,38 @@ export default function OrdersAdmin() {
                                                 </div>
                                             );
                                         })()}
+
+                                        {order.shipment?.trackingNumber && (
+                                            <div className="mt-4 pt-4 border-t-2 border-hackclub-smoke flex flex-wrap items-center gap-x-4 gap-y-1 text-sm">
+                                                <span className="font-bold text-hackclub-dark">
+                                                    📦 {order.shipment.carrier || 'Shipped'}{order.shipment.service ? ` ${order.shipment.service}` : ''}
+                                                </span>
+                                                {order.shipment.trackingUrl ? (
+                                                    <a
+                                                        href={order.shipment.trackingUrl}
+                                                        target="_blank"
+                                                        rel="noreferrer"
+                                                        onClick={(e) => e.stopPropagation()}
+                                                        className="font-mono text-hackclub-blue hover:underline"
+                                                    >
+                                                        {order.shipment.trackingNumber}
+                                                    </a>
+                                                ) : (
+                                                    <span className="font-mono text-hackclub-slate">{order.shipment.trackingNumber}</span>
+                                                )}
+                                                {order.shipment.labelUrl && (
+                                                    <a
+                                                        href={order.shipment.labelUrl}
+                                                        target="_blank"
+                                                        rel="noreferrer"
+                                                        onClick={(e) => e.stopPropagation()}
+                                                        className="text-hackclub-slate hover:text-hackclub-dark font-bold underline"
+                                                    >
+                                                        Label PDF
+                                                    </a>
+                                                )}
+                                            </div>
+                                        )}
 
                                         {selectedOrder?.id === order.id && order.statusHistory && order.statusHistory.length > 0 && (
                                             <motion.div
@@ -289,6 +440,30 @@ export default function OrdersAdmin() {
                             )}
                         </AnimatePresence>
                     </div>
+
+                    {totalPages > 1 && (
+                        <div className="flex items-center justify-center gap-4 mt-8">
+                            <button
+                                type="button"
+                                onClick={() => setPage((p) => Math.max(1, p - 1))}
+                                disabled={clampedPage <= 1}
+                                className="px-4 py-2 rounded-full text-sm font-bold border-2 border-hackclub-smoke text-hackclub-slate hover:border-hackclub-slate disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+                            >
+                                ← Prev
+                            </button>
+                            <span className="text-sm font-bold text-hackclub-muted">
+                                Page {clampedPage} of {totalPages}
+                            </span>
+                            <button
+                                type="button"
+                                onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+                                disabled={clampedPage >= totalPages}
+                                className="px-4 py-2 rounded-full text-sm font-bold border-2 border-hackclub-smoke text-hackclub-slate hover:border-hackclub-slate disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+                            >
+                                Next →
+                            </button>
+                        </div>
+                    )}
                 </motion.div>
             </div>
         </div>

--- a/src/app/admin/stats/page.tsx
+++ b/src/app/admin/stats/page.tsx
@@ -11,6 +11,13 @@ interface StatsData {
     totalRevenue: string;
     ordersByStatus: Record<string, number>;
     topProducts: Array<{ id: string; name: string; quantity: number; revenue: number }>;
+    cashRevenue: string;
+    pointsSpent: number;
+    guestOrderCount: number;
+    studentOrderCount: number;
+    timeSeries: Array<{ date: string; revenue: number; orders: number }>;
+    abandonedSessions: number;
+    lowStockCount: number;
 }
 
 export default function StatsAdmin() {
@@ -148,6 +155,45 @@ export default function StatsAdmin() {
                                 </motion.div>
                             </div>
 
+                            {/* Operational cards */}
+                            <div className="grid grid-cols-2 md:grid-cols-4 gap-6">
+                                <div className="bg-white rounded-2xl shadow-lg border-2 border-hackclub-smoke p-6">
+                                    <p className="text-hackclub-muted font-bold text-sm">Cash Revenue</p>
+                                    <p className="text-3xl font-black text-hackclub-green mt-2">${stats.cashRevenue}</p>
+                                    <p className="text-xs text-hackclub-slate mt-1">{stats.guestOrderCount} card order{stats.guestOrderCount === 1 ? '' : 's'}</p>
+                                </div>
+                                <div className="bg-white rounded-2xl shadow-lg border-2 border-hackclub-smoke p-6">
+                                    <p className="text-hackclub-muted font-bold text-sm">Points Spent</p>
+                                    <p className="text-3xl font-black text-hackclub-blue mt-2">{stats.pointsSpent.toLocaleString()}</p>
+                                    <p className="text-xs text-hackclub-slate mt-1">{stats.studentOrderCount} points order{stats.studentOrderCount === 1 ? '' : 's'}</p>
+                                </div>
+                                <Link href="/admin/inventory">
+                                    <div className={`bg-white rounded-2xl shadow-lg border-2 p-6 transition-colors ${stats.lowStockCount > 0 ? 'border-hackclub-orange/40 hover:border-hackclub-orange' : 'border-hackclub-smoke hover:border-hackclub-slate'}`}>
+                                        <p className="text-hackclub-muted font-bold text-sm">Low Stock</p>
+                                        <p className={`text-3xl font-black mt-2 ${stats.lowStockCount > 0 ? 'text-hackclub-orange' : 'text-hackclub-dark'}`}>{stats.lowStockCount}</p>
+                                        <p className="text-xs text-hackclub-slate mt-1">variants ≤ 5 left</p>
+                                    </div>
+                                </Link>
+                                <div className="bg-white rounded-2xl shadow-lg border-2 border-hackclub-smoke p-6">
+                                    <p className="text-hackclub-muted font-bold text-sm">Abandoned</p>
+                                    <p className="text-3xl font-black text-hackclub-dark mt-2">{stats.abandonedSessions}</p>
+                                    <p className="text-xs text-hackclub-slate mt-1">expired card sessions</p>
+                                </div>
+                            </div>
+
+                            {/* Revenue over time */}
+                            {stats.timeSeries.length > 0 && (
+                                <motion.div
+                                    initial={{ opacity: 0, y: 20 }}
+                                    animate={{ opacity: 1, y: 0 }}
+                                    transition={{ delay: 0.35 }}
+                                    className="bg-white rounded-2xl shadow-lg border-2 border-hackclub-smoke p-6"
+                                >
+                                    <h2 className="text-2xl font-black text-hackclub-dark mb-6">Revenue over time</h2>
+                                    <RevenueChart data={stats.timeSeries} />
+                                </motion.div>
+                            )}
+
                             {/* Orders by Status */}
                             <motion.div
                                 initial={{ opacity: 0, y: 20 }}
@@ -201,6 +247,35 @@ export default function StatsAdmin() {
                         </div>
                     )}
                 </motion.div>
+            </div>
+        </div>
+    );
+}
+
+/**
+ * Lightweight inline-SVG bar chart for daily revenue. No external chart library
+ * (keeps the bundle small and is CSP-safe). Bars scale to the max day; hover
+ * shows the exact value via the native title tooltip.
+ */
+function RevenueChart({ data }: { data: Array<{ date: string; revenue: number; orders: number }> }) {
+    const max = Math.max(1, ...data.map((d) => d.revenue));
+    // Cap the number of labelled ticks so dense ranges stay readable.
+    const labelEvery = Math.ceil(data.length / 8);
+    return (
+        <div className="overflow-x-auto">
+            <div className="flex items-end gap-1.5 min-w-full h-48" style={{ minWidth: `${data.length * 16}px` }}>
+                {data.map((d, i) => (
+                    <div key={d.date} className="flex-1 flex flex-col items-center justify-end group" style={{ minWidth: '10px' }}>
+                        <div
+                            className="w-full bg-hackclub-red/80 group-hover:bg-hackclub-red rounded-t transition-colors"
+                            style={{ height: `${Math.max(2, (d.revenue / max) * 100)}%` }}
+                            title={`${d.date}: $${d.revenue.toFixed(2)} · ${d.orders} order${d.orders === 1 ? '' : 's'}`}
+                        />
+                        <span className="text-[9px] text-hackclub-muted mt-1 whitespace-nowrap" style={{ visibility: i % labelEvery === 0 ? 'visible' : 'hidden' }}>
+                            {d.date.slice(5)}
+                        </span>
+                    </div>
+                ))}
             </div>
         </div>
     );

--- a/src/app/api/admin/audit/route.ts
+++ b/src/app/api/admin/audit/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '../../auth/[...nextauth]/route';
+import { requireAdminPermission } from '../../../../lib/adminAuth';
+import { readAudit } from '../../../../lib/auditLog';
+
+/**
+ * Read the admin audit trail. Gated on canViewStats so any admin who can see the
+ * dashboard can see who did what; the actions themselves stay behind their own
+ * permission gates.
+ */
+export async function GET(request: Request) {
+    const session = await getServerSession(authOptions);
+    const can = await requireAdminPermission(session, 'canViewStats');
+    if (!can.allowed) return NextResponse.json({ error: 'Unauthorized' }, { status: 403 });
+
+    const limit = Math.min(500, Math.max(1, parseInt(new URL(request.url).searchParams.get('limit') || '100', 10) || 100));
+    const entries = await readAudit(limit);
+    return NextResponse.json({ entries });
+}

--- a/src/app/api/admin/orders/[id]/route.ts
+++ b/src/app/api/admin/orders/[id]/route.ts
@@ -6,6 +6,8 @@ import { requireAdminPermission } from '../../../../../lib/adminAuth';
 import { getGuestOrder, updateGuestOrder } from '../../../../../lib/guestOrders';
 import { mirrorOrder } from '../../../../../lib/airtableMirror';
 import { getStripe, isStripeConfigured } from '../../../../../lib/stripe';
+import { restock } from '../../../../../lib/inventory';
+import { recordAudit, AuditAction } from '../../../../../lib/auditLog';
 import { sendEmail, buildStatusUpdate } from '../../../../../lib/email';
 import { Order, OrderStatusUpdate } from '../../../../../types/Order';
 import { PointsTransaction } from '../../../../../types/Points';
@@ -41,6 +43,11 @@ export async function POST(request: Request, { params }: { params: { id: string 
     }
 
     const orderId = params.id;
+    const actorId = session?.user?.id || 'unknown';
+    const actorEmail = session?.user?.email || undefined;
+    const audit = (action: AuditAction, summary: string, metadata?: Record<string, unknown>) =>
+        void recordAudit({ action, actorId, actorEmail, target: orderId, summary, metadata });
+
     const { action, message } = (await request.json()) as { action: Action; message?: string };
 
     const isTestToggle = action === 'mark-test' || action === 'unmark-test';
@@ -55,11 +62,13 @@ export async function POST(request: Request, { params }: { params: { id: string 
         if (guest) {
             const updated = await updateGuestOrder(orderId, { isTest });
             if (updated) void mirrorOrder(updated);
+            audit(`order.${action}` as AuditAction, `${isTest ? 'Marked' : 'Unmarked'} order #${orderId.slice(-8)} as test`);
             return NextResponse.json({ order: updated });
         }
         const updated = await setStudentOrderField(orderId, { isTest });
         if (!updated) return NextResponse.json({ error: 'Order not found' }, { status: 404 });
         void mirrorOrder(updated);
+        audit(`order.${action}` as AuditAction, `${isTest ? 'Marked' : 'Unmarked'} order #${orderId.slice(-8)} as test`);
         return NextResponse.json({ order: updated });
     }
 
@@ -81,6 +90,10 @@ export async function POST(request: Request, { params }: { params: { id: string 
                         return NextResponse.json({ error: 'Stripe refund failed. Check the dashboard.' }, { status: 502 });
                     }
                 }
+                // Return the sold units to stock (best-effort).
+                if (guest.inventoryHold && guest.inventoryHold.length > 0) {
+                    void restock(guest.inventoryHold);
+                }
             }
 
             const updated = await updateGuestOrder(orderId, {
@@ -92,6 +105,7 @@ export async function POST(request: Request, { params }: { params: { id: string 
                 void mirrorOrder(updated);
                 if (updated.guestEmail) void sendEmail(buildStatusUpdate(updated, updated.guestEmail, message));
             }
+            audit(`order.${action}` as AuditAction, `${actionLabel(action)} guest order #${orderId.slice(-8)} ($${guest.totalAmount.toFixed(2)})`, message ? { message } : undefined);
             return NextResponse.json({ order: updated });
         }
 
@@ -102,6 +116,7 @@ export async function POST(request: Request, { params }: { params: { id: string 
         }
         if (result.email) void sendEmail(buildStatusUpdate(result.order, result.email, message));
         void mirrorOrder(result.order);
+        audit(`order.${action}` as AuditAction, `${actionLabel(action)} points order #${orderId.slice(-8)}${result.pointsRefunded ? ` (+${result.pointsRefunded} pts refunded)` : ''}`, message ? { message } : undefined);
         return NextResponse.json({ order: result.order, pointsRefunded: result.pointsRefunded });
     } catch (error) {
         console.error('[Admin order] Error:', error);
@@ -111,6 +126,10 @@ export async function POST(request: Request, { params }: { params: { id: string 
 
 function historyEntry(status: Order['status'], message?: string): OrderStatusUpdate {
     return { status, timestamp: new Date(), ...(message ? { message } : {}) };
+}
+
+function actionLabel(action: StatusAction): string {
+    return { approve: 'Approved', deny: 'Denied', fulfill: 'Fulfilled', refund: 'Refunded' }[action];
 }
 
 /**

--- a/src/app/api/admin/stats/route.ts
+++ b/src/app/api/admin/stats/route.ts
@@ -4,6 +4,8 @@ import { Redis } from '@upstash/redis';
 import { authOptions } from '../../auth/[...nextauth]/route';
 import { requireAdminPermission } from '../../../../lib/adminAuth';
 import { Order } from '../../../../types/Order';
+import { Product } from '../../../../types/Admin';
+import { getVariantStocks } from '../../../../lib/inventory';
 
 const redis = new Redis({
     url: process.env.UPSTASH_REDIS_REST_URL!,
@@ -94,12 +96,56 @@ export async function GET(request: Request) {
             .slice(0, 10)
             .map(([name, data]) => ({ id: name, ...data }));
 
+        // Points vs cash split (real orders): cash revenue (USD) vs points spent.
+        const cashRevenue = realOrders.filter(o => o.pathway === 'guest').reduce((s, o) => s + o.totalAmount, 0);
+        const pointsSpent = realOrders.filter(o => o.pathway === 'student').reduce((s, o) => s + (o.pointsSpent || 0), 0);
+        const guestOrderCount = realOrders.filter(o => o.pathway === 'guest').length;
+        const studentOrderCount = realOrders.filter(o => o.pathway === 'student').length;
+
+        // Revenue + order count over time, bucketed by day across the period.
+        const dayBuckets: Record<string, { revenue: number; orders: number }> = {};
+        for (const o of realOrders) {
+            const day = new Date(o.createdAt).toISOString().slice(0, 10);
+            if (!dayBuckets[day]) dayBuckets[day] = { revenue: 0, orders: 0 };
+            dayBuckets[day].revenue += o.totalAmount;
+            dayBuckets[day].orders += 1;
+        }
+        const timeSeries = Object.entries(dayBuckets)
+            .sort((a, b) => a[0].localeCompare(b[0]))
+            .map(([date, v]) => ({ date, revenue: Number(v.revenue.toFixed(2)), orders: v.orders }));
+
+        // Abandoned/expired guest sessions (orders denied while still unpaid),
+        // scoped to the selected period like the other aggregates.
+        const abandonedSessions = filteredOrders.filter(o => o.pathway === 'guest' && o.paymentStatus === 'unpaid' && o.status === 'denied').length;
+
+        // Low-stock count across tracked variants (available ≤ 5).
+        let lowStockCount = 0;
+        try {
+            const productKeys = await redis.keys('product:*');
+            const variantIds: string[] = [];
+            for (const key of productKeys) {
+                const p = await redis.get<Product>(key);
+                for (const v of p?.variants || []) variantIds.push(String(v.variant_id || v.id));
+            }
+            const stocks = await getVariantStocks(variantIds);
+            lowStockCount = Object.values(stocks).filter(s => s.available !== null && s.available <= 5).length;
+        } catch {
+            // Best-effort; leave at 0 if inventory read fails.
+        }
+
         return NextResponse.json({
             period,
             totalOrders,
             totalRevenue: totalRevenue.toFixed(2),
             ordersByStatus,
             topProducts,
+            cashRevenue: cashRevenue.toFixed(2),
+            pointsSpent,
+            guestOrderCount,
+            studentOrderCount,
+            timeSeries,
+            abandonedSessions,
+            lowStockCount,
             orders: filteredOrders,
         });
     } catch {

--- a/src/app/api/admin/users/[id]/points/route.ts
+++ b/src/app/api/admin/users/[id]/points/route.ts
@@ -4,6 +4,7 @@ import { Redis } from '@upstash/redis';
 import { authOptions } from '../../../../auth/[...nextauth]/route';
 import { requireAdminPermission } from '../../../../../../lib/adminAuth';
 import { mirrorUser } from '../../../../../../lib/airtableMirror';
+import { recordAudit } from '../../../../../../lib/auditLog';
 
 const redis = new Redis({
     url: process.env.UPSTASH_REDIS_REST_URL!,
@@ -50,6 +51,15 @@ export async function PUT(
         const transactions = (await redis.get<any[]>(txKey(userId))) || [];
         transactions.unshift(transaction);
         await redis.set(txKey(userId), transactions);
+
+        void recordAudit({
+            action: amount >= 0 ? 'points.grant' : 'points.deduct',
+            actorId: session?.user?.id || 'unknown',
+            actorEmail: session?.user?.email || undefined,
+            target: userId,
+            summary: `${amount >= 0 ? 'Granted' : 'Deducted'} ${Math.abs(amount)} pts ${amount >= 0 ? 'to' : 'from'} ${userId} (→ ${newBalance}). Reason: ${reason}`,
+            metadata: { amount, previousBalance: currentBalance, newBalance, reason },
+        });
 
         return NextResponse.json({
             userId,

--- a/src/app/products/[id]/page.tsx
+++ b/src/app/products/[id]/page.tsx
@@ -48,8 +48,10 @@ const ProductPage = () => {
         fetchProduct();
     }, [productId]);
 
+    const isInStock = (v: Variant | null) => !v || v.available === undefined || v.available === null || v.available > 0;
+
     const handleAddToCart = () => {
-        if (product && selectedVariant && isAvailableOn(selectedVariant, pathway)) {
+        if (product && selectedVariant && isAvailableOn(selectedVariant, pathway) && isInStock(selectedVariant)) {
             const cartItem = {
                 id: product.id,
                 name: selectedVariant.name,
@@ -102,8 +104,11 @@ const ProductPage = () => {
     // Strict path separation: a variant is buyable only if it's priced for the
     // active pathway, and the product is only purchasable at all if at least one
     // variant is.
-    const selectedAvailable = !!selectedVariant && isAvailableOn(selectedVariant, pathway);
+    const selectedInStock = isInStock(selectedVariant);
+    const selectedAvailable = !!selectedVariant && isAvailableOn(selectedVariant, pathway) && selectedInStock;
     const anyVariantAvailable = variants.some((variant) => isAvailableOn(variant, pathway));
+    const selectedStock = selectedVariant?.available;
+    const selectedLow = typeof selectedStock === 'number' && selectedStock > 0 && selectedStock <= 5;
 
     return (
         <div
@@ -142,6 +147,11 @@ const ProductPage = () => {
                                 ) : (
                                     <p className="text-lg text-gray-400 font-medium">Not available</p>
                                 )}
+                                {selectedStock === 0 ? (
+                                    <p className="mt-2 inline-block px-3 py-1 rounded-full text-sm font-black bg-hackclub-dark text-white">Sold out</p>
+                                ) : selectedLow ? (
+                                    <p className="mt-2 inline-block px-3 py-1 rounded-full text-sm font-black bg-hackclub-orange text-white">Only {selectedStock} left</p>
+                                ) : null}
                             </div>
                         )}
 
@@ -167,6 +177,7 @@ const ProductPage = () => {
                                         <option key={`${variant.id || variant.variant_id}_${idx}`} value={variant.id || variant.variant_id}>
                                             {variant.size || 'Default'} / {variant.color || 'Default'}
                                             {getDisplayPrice(variant, pathway) ? ` - ${getDisplayPrice(variant, pathway)}` : ''}
+                                            {variant.available === 0 ? ' (sold out)' : ''}
                                         </option>
                                     ))}
                                 </select>
@@ -185,7 +196,7 @@ const ProductPage = () => {
                                 }
                                 onClick={handleAddToCart}
                             >
-                                {selectedAvailable ? 'Add to Cart' : 'Not available'}
+                                {selectedAvailable ? 'Add to Cart' : !selectedInStock ? 'Sold out' : 'Not available'}
                             </motion.button>
                         ) : (
                             <div className="rounded-2xl border-2 border-gray-200 bg-hackclub-smoke p-5 text-center">


### PR DESCRIPTION
Replaces #11 (auto-closed when its stacked base merged). Base `store-v2`. Final track of the upgrade program.

## What
- **/admin/orders**: free-text search (order #, email, user, item, tracking), status + pathway filters, pagination, CSV export of the filtered set.
- **Audit log**: refunds, point grants/deductions, status changes, shipping, and stock edits → capped Redis list. `/admin/audit` page + `/api/admin/audit` (gated `canViewStats`); `recordAudit` wired into order/points/shipping/inventory routes. Dashboard card added.
- **/admin/stats**: cash-revenue vs points-spent split, daily revenue bar chart (inline SVG, no dep), low-stock + abandoned-session cards.
- Adds `SHOP_UPGRADE_PROMPT.md`.

## Review fixes folded in
- CSV export now neutralizes spreadsheet formula injection (leading `= + - @` → prefixed).
- `abandonedSessions` now respects the selected period like every other aggregate.

Reviewed: audit log can't throw into callers; hooks unconditional; pagination clamps; stats safe on empty data (no div-by-zero); RevenueChart guarded. No blockers.

## Verify
`tsc`, `build`, `lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)