### PR TITLE
Finance: inventory costing, valuation & weekly reports

### DIFF
--- a/FINANCE_INVENTORY_PROMPT.md
+++ b/FINANCE_INVENTORY_PROMPT.md
@@ -1,0 +1,199 @@
+# Self-prompt: Finance-grade Inventory & Costing system
+
+> A self-contained build prompt. Hand this back to yourself (or a fresh agent) to
+> execute the work end to end. Grounded in the actual `store-v2` codebase —
+> read the "Ground truth" section before writing any code.
+
+## The ask (in the user's words)
+
+> "We need to make a very very good Inventory system, like what's on hand, how
+> much we paid for it, weekly reports, graphs, and basically everything for our
+> finance team to not be mad."
+
+## What already exists (do NOT rebuild)
+
+The shop **already has an operational inventory layer** (shipped 2026-06-22, see
+`docs/INVENTORY.md` + `src/lib/inventory.ts`). It answers *"how many units can we
+sell right now"*: per-variant `stock`, `reserved` overlay, `available = max(0,
+stock − reserved)`, reserve→commit/release across Stripe + points pathways,
+oversell protection, Airtable-authoritative base with Redis cache, `/admin/inventory`
+quick-adjust page.
+
+It has **zero financial dimension.** That is the gap this build fills.
+
+## What we're building: the *finance* layer
+
+A **costing & valuation** layer that sits on top of the existing unit layer and
+answers the questions a finance team actually asks:
+
+1. **What's on hand, and what is it worth?** — units × unit cost = inventory
+   valuation, per variant / product / category and in total.
+2. **How much did we pay for it?** — a cost basis per variant, captured when stock
+   is received (purchases / receiving records), with weighted-average cost.
+3. **What did we make?** — per-order and per-period **COGS** and **gross margin**
+   (revenue − COGS), for the cash (Stripe) pathway. Points orders contribute COGS
+   (real money left the building) but $0 cash revenue — surface both so margin
+   math is honest.
+4. **Weekly reports** — a scheduled/queryable weekly rollup: units sold, revenue,
+   COGS, gross margin, units received, spend, ending on-hand valuation, low-stock
+   and dead-stock flags. Exportable to CSV (finance lives in spreadsheets).
+5. **Graphs** — inline-SVG (no chart lib; match `RevenueChart` in
+   `src/app/admin/stats/page.tsx`): valuation over time, weekly margin, spend vs
+   revenue, top products by margin.
+
+## Ground truth (read these before coding)
+
+| Thing | Location | Notes |
+|---|---|---|
+| Unit inventory model | `docs/INVENTORY.md`, `src/lib/inventory.ts` | reserve/commit/release; `available = stock − reserved`; untracked = unlimited |
+| Admin Product type | `src/types/Admin.ts` → `Product` / `ProductVariant` | variants have `price_cash?`, `price_points?`, `stock?`, `weightOz?`. **Add `unitCost?` here.** |
+| Order type | `src/types/Order.ts` → `Order` / `OrderItem` | `pathway` (`student`/`guest`), `paymentMethod`, `totalAmount` (USD), `pointsSpent`, `isTest`, `items[]`. `OrderItem` has `id`,`name`,`price`,`quantity` — **no variantId or cost today.** |
+| Redis layout | — | products: `product:*`; student orders: `user:*:orders` (array); guest orders: `order:*` (single). Inventory: `inventory:{variantId}`, `inventory:{variantId}:reserved` |
+| Admin auth | `src/lib/adminAuth.ts`, `src/types/Admin.ts` | `requireAdminPermission(session, perm)`. Perms: `canManageProducts`, `canViewStats`, `canManageUsers`, `canManageBalance`, `canManageCoupons`, `canManageAdmins`. Roles: manager / store_manager / reader |
+| Audit log | `src/lib/auditLog.ts` → `recordAudit(...)` | capped Redis list; wire every financial mutation through it |
+| Airtable mirror | `src/lib/airtableMirror.ts` → `mirrorProduct(p)` | fire-and-forget, never throws |
+| Existing stats API | `src/app/api/admin/stats/route.ts` | how to enumerate all orders across both key patterns; reuse the iteration shape |
+| Chart pattern | `src/app/admin/stats/page.tsx` → `RevenueChart` | inline SVG/divs, `title` tooltips, CSP-safe, no deps |
+| Inventory admin page | `src/app/admin/inventory/page.tsx` | Hack Club design system (`hackclub-*` tailwind tokens, framer-motion, rounded-full buttons) to match |
+
+## Hard invariants (from `[[shop-upgrade-roadmap]]` — never regress)
+
+- **Fire-and-forget safe:** every new finance read/write degrades gracefully on a
+  Redis/Airtable hiccup. A costing failure must **never** block a sale or break a
+  checkout/webhook path. Mirror the `inventory.ts` / `email.ts` safe-no-op style.
+- **Admin gates on BOTH page and API.** Reuse `requireAdminPermission`. Finance
+  reads → `canViewStats`; cost edits / receiving → `canManageProducts` (or a new
+  `canManageFinance` perm — see decisions).
+- **Exclude `isTest` orders** from all financial aggregates (match stats route).
+- **No new dependencies.** Inline-SVG charts only. CSV export must be
+  **formula-injection-safe** (match the existing `/admin/orders` CSV escaping —
+  prefix `=+-@` cells with `'`).
+- **Don't touch the hot checkout/webhook path's behavior.** Capturing per-line
+  cost onto orders is additive and must be wrapped so a missing cost = `0` COGS,
+  never a throw.
+
+## Architecture
+
+### 1. Cost basis on variants
+- Add `unitCost?: number` (USD) to `ProductVariant` in `src/types/Admin.ts` and to
+  the admin product form. This is the *current* standard cost — what we pay per
+  unit. Optional; missing = unknown cost (treated as `0` in COGS but flagged
+  "uncosted" in reports so finance can see coverage).
+
+### 2. Receiving / purchases ledger (how much we paid)
+New lib `src/lib/costing.ts` + Redis-backed ledger:
+- `receipt:{id}` records: `{ id, variantId, productName, variantName, quantity,
+  unitCost, totalCost, receivedAt, note, actorId }`. Append-only.
+- Index: `receipts:index` (capped list of ids, like the audit log) +
+  `receipts:variant:{variantId}` for per-variant history.
+- On receiving stock: (a) write the receipt, (b) recompute **weighted-average
+  unit cost** for that variant and store it back on the variant (`unitCost`), (c)
+  bump unit stock via the existing `setStock` / product update path so the two
+  layers stay consistent, (d) `recordAudit`, (e) `mirrorProduct`.
+- This makes "how much we paid for it" a real, auditable number, not a guess.
+
+### 3. COGS capture on sale
+- Extend `OrderItem` with optional `variantId?` and `unitCost?` so each sold line
+  carries the cost basis **at time of sale** (point-in-time, so later cost changes
+  don't rewrite history). Populate in both checkout routes from the variant's
+  current `unitCost`, wrapped defensively (missing → omit/0).
+- Reports compute order COGS = `Σ(line.quantity × (line.unitCost ?? variant
+  fallback ?? 0))`. Provide a fallback that looks up the *current* variant cost for
+  legacy orders that predate the field, clearly labelled "estimated".
+
+### 4. Finance lib (`src/lib/finance.ts`)
+Pure aggregation over orders + products + receipts. Functions:
+- `getInventoryValuation()` → per-variant/product/category on-hand units × unitCost,
+  plus totals + uncosted-coverage %.
+- `getCogsAndMargin(period)` → revenue, COGS, gross margin, margin %, split by
+  cash vs points pathway; per-product breakdown; top/bottom by margin.
+- `getSpend(period)` → receiving spend from the ledger.
+- `getWeeklyReport(weekStart?)` → one ISO-week rollup combining the above + units
+  sold/received + dead-stock (no sales in N weeks) + low-stock. This is the
+  finance team's headline artifact.
+- `getValuationTimeSeries()` / weekly series for the charts.
+All read-only, fire-and-forget safe, exclude `isTest`.
+
+### 5. API routes (under `src/app/api/admin/finance/`)
+- `GET /api/admin/finance/overview?period=` → valuation + COGS/margin + spend
+  (powers the dashboard). `canViewStats`.
+- `GET /api/admin/finance/weekly?week=` → weekly report JSON. `canViewStats`.
+- `GET /api/admin/finance/weekly/export?week=` → CSV (injection-safe). `canViewStats`.
+- `POST /api/admin/finance/receiving` → record a stock receipt (qty + unitCost),
+  updates avg cost + stock + audit + mirror. `canManageProducts`.
+- `GET /api/admin/finance/receiving?variantId=` → receipt history. `canViewStats`.
+
+### 6. Admin UI
+- New `src/app/admin/finance/page.tsx` — the finance dashboard:
+  - **KPI cards:** on-hand valuation, period revenue, period COGS, gross margin
+    ($ and %), receiving spend, uncosted-variant count.
+  - **Charts (inline SVG):** weekly gross margin (bars), valuation trend (line/bars),
+    spend vs revenue, top-10 products by margin.
+  - **Weekly report panel:** week picker + table + "Export CSV" + "Email/print"
+    affordance; dead-stock and low-stock callouts.
+  - **Receiving form:** pick variant → qty + unit cost → "Receive stock" (writes
+    ledger + bumps stock). Recent receipts table below.
+  - Period selector (week/month/year/all) mirroring the stats page.
+  - Match the Hack Club design system exactly (tokens, motion, layout) — model on
+    `src/app/admin/inventory/page.tsx` and `src/app/admin/stats/page.tsx`.
+- Add a **Finance / Inventory Value** card + link to the admin dashboard
+  (`src/app/admin/page.tsx`) and cross-link from `/admin/inventory`.
+
+### 7. Weekly report delivery (graphs + report for finance)
+- Primary: the dashboard's week picker + CSV export (always works, no infra).
+- Optional stretch (gate behind config, safe-no-op if unset, like `email.ts`):
+  a `POST /api/admin/finance/weekly/send` that emails the finance distro the
+  week's summary via the existing `src/lib/email.ts`. Only build if email lib
+  supports it cleanly; otherwise document the `/schedule` path and skip.
+
+### 8. Docs
+- `docs/FINANCE.md`: the costing model (weighted-avg cost, point-in-time COGS,
+  points-vs-cash margin treatment, valuation formula), Redis keys, where numbers
+  come from, and the known approximations (legacy orders w/o line cost, Redis-leads-
+  Airtable between counts). Finance must be able to trust and audit the numbers.
+
+## Correctness notes / gotchas
+
+- **`OrderItem` has no `variantId` today.** Confirm in both checkout routes whether
+  the variant id is available at line-build time (it should be — pricing is dual
+  per variant). If a line truly can't be mapped to a variant, COGS for it falls to
+  the fallback and the report flags partial coverage. Don't fabricate a mapping.
+- **Points orders:** revenue (USD) = 0 but COGS > 0. Report **cash gross margin**
+  separately from **points-fulfillment cost** so a heavy points week doesn't read
+  as a catastrophic negative margin. Be explicit in the UI labels.
+- **Weighted-average cost** recompute must be monotonic and safe: `newAvg =
+  (oldUnits×oldAvg + recvUnits×recvCost) / (oldUnits + recvUnits)`, guarding
+  div-by-zero and missing oldAvg. Document the choice (avg, not FIFO) in `FINANCE.md`.
+- **Reserved units in valuation:** value **on-hand = `stock`** (what we physically
+  have), not `available` — reserved units are still ours until the sale commits.
+  State this explicitly.
+- **CSV injection:** reuse the exact escaping from the `/admin/orders` CSV export.
+- **Idempotency of receiving:** a double-submit shouldn't double-count. Use a
+  client-supplied or generated receipt id and a Redis `SET NX` guard, mirroring
+  `claimOrderSettlement`.
+
+## Definition of done
+
+- [ ] `unitCost` on variant type + admin product form; reads/writes round-trip.
+- [ ] Receiving ledger writes receipts, recomputes weighted-avg cost, bumps stock,
+      audits, mirrors — all fire-and-forget safe.
+- [ ] COGS captured point-in-time on new orders (both pathways), defensively wrapped.
+- [ ] `finance.ts` aggregations correct, test-order-excluded, fail-soft.
+- [ ] All 5 API routes gated on both page + API, correct permission each.
+- [ ] `/admin/finance` dashboard: KPI cards + ≥3 inline-SVG charts + weekly report
+      table + CSV export + receiving form, on-brand.
+- [ ] Linked from admin dashboard + inventory page.
+- [ ] `docs/FINANCE.md` explains the model and its approximations.
+- [ ] `npm run build` / lint clean. No new deps. No checkout/webhook regression.
+- [ ] Report back: what shipped, the numbers' provenance, known approximations,
+      and any follow-ups (matches the "build autonomously, report at the end" style).
+
+## Decisions (RESOLVED 2026-06-23)
+
+1. **Access:** add a new **`canManageFinance`** permission. Managers get it by
+   default; store_manager/reader do not. Gate finance reads + receiving on it
+   (not on `canViewStats`/`canManageProducts`).
+2. **Costing:** **weighted-average cost** (not FIFO).
+3. **Weekly delivery:** **dashboard + CSV export only.** No email endpoint.
+   (Skip §7's optional email stretch entirely.)
+4. **Scope:** **full build now, autonomous, report at the end.**

--- a/docs/FINANCE.md
+++ b/docs/FINANCE.md
@@ -1,0 +1,155 @@
+# Finance & costing model
+
+How the shop tracks **money tied up in inventory** — cost basis, valuation, cost
+of goods sold (COGS), gross margin, purchasing spend, and the weekly report. This
+is a separate layer from the operational stock model in
+[`INVENTORY.md`](./INVENTORY.md): that one answers *"how many units can we sell"*,
+this one answers *"how much did we pay, what's it worth, and what did we make"*.
+
+Read this before touching `src/lib/costing.ts`, `src/lib/finance.ts`, or the
+`/admin/finance` page. Finance must be able to trust and audit these numbers, so
+every approximation is spelled out below.
+
+## The two layers, side by side
+
+| | Unit layer (`inventory.ts`) | Finance layer (`costing.ts` + `finance.ts`) |
+|---|---|---|
+| Question | How many can we sell right now? | How much did we pay / what's it worth / what did we make? |
+| Per variant | `stock`, `reserved`, `available` | `unitCost` (weighted-avg), receipt ledger |
+| Source of truth | Airtable base stock → Redis cache | `variant.unitCost` on the product record + `receipts:*` ledger in Redis |
+| Mutates on sale | commit decrements stock | nothing — COGS is *read* from order lines |
+
+The finance layer **never gates a sale** and never mutates stock except through the
+same `setStock` path the admin quick-adjust uses. A Redis/Airtable hiccup degrades
+to empty/zero, exactly like `email.ts` and `airtableMirror.ts`.
+
+## Cost basis: weighted-average
+
+Each variant carries an optional `unitCost` (USD per unit) — the **current standard
+cost**, what we pay for one. It can be set by hand in the product form, or
+recomputed automatically when stock is received.
+
+**Receiving** (recording a purchase) is the heart of the model. When staff receive
+`q` units at `c` dollars each (`/admin/finance` → "Receive stock", or
+`POST /api/admin/finance/receiving`), `receiveStock()`:
+
+1. writes an append-only **`Receipt`** (who/what/qty/cost/when/note),
+2. recomputes the variant's weighted-average cost:
+
+   ```
+   newAvg = (oldUnits × oldAvg  +  recvUnits × recvCost) / (oldUnits + recvUnits)
+   ```
+
+   with guards for div-by-zero and a missing prior cost (a never-costed variant
+   simply takes the received cost as its average — phantom $0 units don't drag it
+   down; see `blendCost()`),
+3. bumps unit `stock` by `q` through the product record **and** the inventory
+   cache (`setStock`), so the two layers never drift,
+4. records an audit entry (`inventory.receive`) and re-mirrors the product to
+   Airtable.
+
+We chose **weighted-average, not FIFO.** For the shop's volume it's the right
+call: stable, easy for finance to reconcile, and it needs no per-receipt cost-layer
+tracking. The trade-off is that valuation doesn't reflect which *specific* lot is
+on the shelf — acceptable here.
+
+**Idempotency:** receiving takes a one-time claim on the receipt id (`SET NX`,
+mirroring `claimOrderSettlement`), so a double-click or retried request can't
+double-count stock or double-blend cost. The dashboard generates a fresh
+`receiptId` per submit.
+
+**Untracked variants:** a variant with no `stock` number is "unlimited" on the
+sell side. Receiving cost data for it sets its `unitCost` but does **not** convert
+it to a counted variant — we don't let a cost entry silently change availability.
+
+## COGS: captured point-in-time on the sale
+
+When an order is placed, each line records the variant's `unitCost` **at that
+moment** onto the `OrderItem` (`variantId` + `unitCost`), in
+`validateCartItems()` (the trusted server-side path both checkout routes use). So
+COGS is historically correct even if the variant's standard cost changes later.
+
+```
+line COGS = quantity × (item.unitCost   if captured at sale
+                        else current variant.unitCost   ← "estimated" fallback
+                        else 0)
+```
+
+Orders placed **before** this layer shipped have no line cost, so they fall back to
+the variant's *current* cost and are flagged. The dashboard shows
+`estimatedLineShare` — the fraction of sold lines using the fallback — so finance
+knows how much of a period's COGS is exact vs. estimated.
+
+## Cash vs. points — why margin is split
+
+The shop sells on two pathways:
+
+- **Guest / Stripe (cash):** real USD revenue. This is the true P&L line — the
+  dashboard's **cash revenue − cash COGS = cash gross margin**.
+- **Student / points:** $0 cash revenue, but the goods still cost us real money to
+  buy. Folding points fulfilment into the same margin would make a heavy points
+  week look like a catastrophic loss.
+
+So we report them **separately**: cash margin is the headline; **points COGS**
+(USD we spent fulfilling points orders) and **points spent** (internal points) are
+shown on their own. `totalCogs = cashCogs + pointsCogs` is the real cost of
+everything that left the building.
+
+## Valuation
+
+```
+variant value      = on-hand units × unitCost     (0 if either is unknown)
+inventory value    = Σ variant value
+```
+
+**On-hand = `variant.stock`** — what we *physically* hold. Reserved (in-flight
+Stripe) units are still ours until the sale commits, so they count toward
+valuation. Untracked (unlimited) variants contribute 0 — there's no finite count to
+value. The dashboard surfaces **cost coverage** (% of tracked variants that have a
+cost) and an **uncosted count** so gaps are visible, not hidden.
+
+## Weekly report
+
+`getWeeklyReport(dateInWeek)` rolls up one ISO week (Mon–Sun): units sold, cash
+revenue / COGS / margin, points COGS + points spent, units received + spend, and
+the **ending inventory value** + low-stock + dead-stock flags at report time.
+
+- **Low stock:** available ≤ 5 (from the unit layer).
+- **Dead stock:** holds value but hasn't sold in 8 weeks — capital sitting idle.
+
+It's exportable as **formula-injection-safe CSV**
+(`/api/admin/finance/weekly/export?week=YYYY-MM-DD` — leading `=,+,-,@` cells are
+prefixed with `'`, matching the orders export). No email/scheduling is wired; the
+week picker + CSV is the delivery mechanism.
+
+## Redis keys
+
+| Key | Meaning | Written by |
+|---|---|---|
+| `receipts:log` | capped list (2000) of all receipts, newest first | `receiveStock` |
+| `receipts:variant:{variantId}` | capped list (200) of one variant's receipts | `receiveStock` |
+| `receipts:claim:{receiptId}` | idempotency claim (30-day TTL) | `receiveStock` |
+| `variant.unitCost` (on `product:*`) | current weighted-avg cost | `receiveStock`, product form |
+
+Order/product enumeration reuses the same patterns as `/api/admin/stats`
+(`user:*:orders` arrays + `order:*` singles + `product:*`). Test orders (`isTest`)
+are excluded from every aggregate.
+
+## Access
+
+All finance reads and receiving require the **`canManageFinance`** permission
+(managers only by default), gated on both the page and every API route. This keeps
+cost basis and margin separate from order stats (`canViewStats`) and product
+editing (`canManageProducts`).
+
+## Known approximations (tell finance these)
+
+1. **Legacy orders** (pre-finance-layer) use current variant cost as an estimate —
+   tracked via `estimatedLineShare`.
+2. **Weighted-average**, not FIFO — valuation doesn't track specific lots.
+3. **Redis leads Airtable between counts** for live stock (inherited from the unit
+   layer) — valuation uses the live Redis base, reconciled on the next sync.
+4. **Refunds** are excluded from COGS/margin (status `refunded`/`denied` skipped),
+   but a refund that restocks goes through the unit layer's `restock`, not a
+   negative receipt — so refunded units re-enter valuation at the variant's current
+   average, not their original cost. Acceptable at this volume.

--- a/src/app/admin/finance/page.tsx
+++ b/src/app/admin/finance/page.tsx
@@ -1,0 +1,634 @@
+'use client';
+
+import { useState, useEffect, useMemo, useCallback } from 'react';
+import { useSession, signIn } from 'next-auth/react';
+import Link from 'next/link';
+import { motion } from 'framer-motion';
+
+// ── Types mirrored from src/lib/finance.ts (kept loose; this is a display layer) ──
+type Period = 'week' | 'month' | 'year' | 'all';
+
+interface ValuationRow {
+    productId: string; variantId: string; productName: string; variantName: string;
+    category?: string; onHand: number | null; unitCost: number | null; value: number; costed: boolean;
+}
+interface Valuation {
+    rows: ValuationRow[]; totalValue: number; totalUnits: number; trackedVariants: number;
+    costedVariants: number; uncostedVariants: number; untrackedVariants: number;
+    byCategory: Array<{ category: string; value: number; units: number }>;
+}
+interface MarginProductRow { name: string; variantId?: string; unitsSold: number; revenue: number; cogs: number; margin: number; marginPct: number | null; }
+interface CogsAndMargin {
+    period: Period; cashRevenue: number; cashCogs: number; cashMargin: number; cashMarginPct: number | null;
+    pointsCogs: number; pointsSpent: number; pointsOrders: number; totalCogs: number; unitsSold: number;
+    ordersCounted: number; estimatedLineShare: number; topByMargin: MarginProductRow[]; bottomByMargin: MarginProductRow[];
+}
+interface Spend { totalSpend: number; receiptCount: number; unitsReceived: number; }
+interface WeekPoint { week: string; weekStart: string; cashRevenue: number; cashCogs: number; cashMargin: number; pointsCogs: number; spend: number; unitsSold: number; unitsReceived: number; orders: number; }
+interface Overview { period: Period; valuation: Valuation; margin: CogsAndMargin; spend: Spend; weeklySeries: WeekPoint[]; generatedAt: string; }
+
+interface Receipt {
+    id: string; productName: string; variantName: string; quantity: number; unitCost: number;
+    totalCost: number; avgCostAfter: number; stockAfter: number | null; receivedAt: string; actorEmail?: string; note?: string;
+}
+interface WeeklyReport {
+    week: string; weekStart: string; weekEnd: string; unitsSold: number; cashRevenue: number; cashCogs: number;
+    cashMargin: number; cashMarginPct: number | null; pointsCogs: number; pointsSpent: number; orders: number;
+    unitsReceived: number; spend: number; receiptCount: number; endingInventoryValue: number; uncostedVariants: number;
+    lowStock: Array<{ variantId: string; productName: string; variantName: string; available: number | null }>;
+    deadStock: Array<{ variantId: string; productName: string; variantName: string; onHand: number; value: number; lastSold: string | null }>;
+}
+
+const usd = (n: number) => `$${(n ?? 0).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+const PERIODS: { id: Period; label: string }[] = [
+    { id: 'week', label: '7 days' }, { id: 'month', label: '30 days' }, { id: 'year', label: '1 year' }, { id: 'all', label: 'All time' },
+];
+
+export default function FinanceAdmin() {
+    const { data: session, status } = useSession();
+    const [period, setPeriod] = useState<Period>('month');
+    const [data, setData] = useState<Overview | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        if (status === 'unauthenticated') signIn('hackclub', { callbackUrl: '/admin/finance' });
+    }, [status]);
+
+    const load = useCallback(async () => {
+        setLoading(true);
+        setError(null);
+        try {
+            const res = await fetch(`/api/admin/finance/overview?period=${period}`);
+            if (!res.ok) {
+                setError(res.status === 403 ? 'You don’t have permission to view finance.' : 'Failed to load finance data');
+                return;
+            }
+            setData(await res.json());
+        } catch {
+            setError('Failed to load finance data');
+        } finally {
+            setLoading(false);
+        }
+    }, [period]);
+
+    useEffect(() => { if (session) load(); }, [session, load]);
+
+    if (status === 'loading' || (session && loading && !data)) {
+        return (
+            <div className="min-h-screen flex items-center justify-center bg-hackclub-smoke">
+                <div className="text-hackclub-dark font-bold">Loading…</div>
+            </div>
+        );
+    }
+    if (!session) return null;
+
+    return (
+        <div className="min-h-screen bg-white text-hackclub-dark"
+            style={{
+                backgroundImage: 'linear-gradient(to right, #e0f2fe 1px, transparent 1px), linear-gradient(to bottom, #e0f2fe 1px, transparent 1px)',
+                backgroundSize: '30px 30px',
+            }}
+        >
+            <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+                <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.4 }}>
+                    <Link href="/admin" className="text-hackclub-slate hover:text-hackclub-dark mb-2 inline-block font-medium">← Back to Dashboard</Link>
+                    <div className="flex flex-wrap items-end justify-between gap-4 mb-2">
+                        <h1 className="text-5xl sm:text-6xl font-black text-hackclub-dark">Finance</h1>
+                        <div className="flex gap-2">
+                            {PERIODS.map((p) => (
+                                <button key={p.id} type="button" onClick={() => setPeriod(p.id)}
+                                    className={`px-4 py-2 rounded-full text-sm font-bold border-2 transition-colors ${period === p.id ? 'bg-hackclub-blue text-white border-hackclub-blue' : 'bg-white text-hackclub-slate border-hackclub-smoke hover:border-hackclub-slate'}`}>
+                                    {p.label}
+                                </button>
+                            ))}
+                        </div>
+                    </div>
+                    <p className="text-lg text-hackclub-slate font-medium mb-6">
+                        On-hand value, cost of goods, margins, purchasing spend, and the weekly report. Cost basis is weighted-average per variant — see <Link href="/admin/inventory" className="text-hackclub-blue hover:underline font-bold">Inventory</Link> for units.
+                    </p>
+
+                    {error && (
+                        <div className="mb-4 p-4 bg-hackclub-red/10 border-2 border-hackclub-red rounded-xl">
+                            <p className="text-hackclub-red font-bold">{error}</p>
+                        </div>
+                    )}
+
+                    {data && (
+                        <>
+                            <KpiGrid data={data} />
+                            <ChartsRow data={data} />
+                            <ValuationPanel valuation={data.valuation} />
+                            <MarginPanel margin={data.margin} />
+                            <WeeklyPanel onReceived={load} />
+                            <ReceivingPanel rows={data.valuation.rows} onReceived={load} />
+                        </>
+                    )}
+                </motion.div>
+            </div>
+        </div>
+    );
+}
+
+// ── KPI cards ────────────────────────────────────────────────────────────────
+function Kpi({ label, value, sub, tone = 'dark' }: { label: string; value: string; sub?: string; tone?: 'dark' | 'green' | 'red' | 'blue' | 'orange' }) {
+    const toneClass = {
+        dark: 'text-hackclub-dark', green: 'text-hackclub-green', red: 'text-hackclub-red', blue: 'text-hackclub-blue', orange: 'text-hackclub-orange',
+    }[tone];
+    return (
+        <div className="bg-white rounded-2xl shadow-lg border-2 border-hackclub-smoke p-5">
+            <div className="text-xs font-black uppercase text-hackclub-muted tracking-wide">{label}</div>
+            <div className={`text-3xl font-black mt-1 ${toneClass}`}>{value}</div>
+            {sub && <div className="text-sm text-hackclub-slate font-medium mt-1">{sub}</div>}
+        </div>
+    );
+}
+
+function KpiGrid({ data }: { data: Overview }) {
+    const { valuation, margin, spend } = data;
+    const marginTone = margin.cashMargin >= 0 ? 'green' : 'red';
+    return (
+        <div className="grid grid-cols-2 lg:grid-cols-3 xl:grid-cols-6 gap-4 mb-6">
+            <Kpi label="Inventory value" value={usd(valuation.totalValue)} sub={`${valuation.totalUnits.toLocaleString()} units on hand`} tone="blue" />
+            <Kpi label="Cash revenue" value={usd(margin.cashRevenue)} sub={`${margin.ordersCounted} orders`} />
+            <Kpi label="Cost of goods" value={usd(margin.cashCogs)} sub={margin.pointsCogs > 0 ? `+ ${usd(margin.pointsCogs)} points fulfilment` : 'cash pathway'} tone="orange" />
+            <Kpi label="Gross margin" value={usd(margin.cashMargin)} sub={margin.cashMarginPct === null ? 'no cash sales' : `${margin.cashMarginPct.toFixed(1)}% of revenue`} tone={marginTone} />
+            <Kpi label="Purchasing spend" value={usd(spend.totalSpend)} sub={`${spend.unitsReceived.toLocaleString()} units received`} tone="red" />
+            <Kpi label="Cost coverage" value={`${valuation.trackedVariants ? Math.round((valuation.costedVariants / valuation.trackedVariants) * 100) : 0}%`} sub={valuation.uncostedVariants > 0 ? `${valuation.uncostedVariants} variants uncosted` : 'all stock costed'} tone={valuation.uncostedVariants > 0 ? 'orange' : 'green'} />
+        </div>
+    );
+}
+
+// ── Charts row ───────────────────────────────────────────────────────────────
+function ChartsRow({ data }: { data: Overview }) {
+    const series = data.weeklySeries;
+    return (
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
+            <Card title="Weekly gross margin (cash)" subtitle="Revenue − COGS, last 12 weeks">
+                <WeeklyMarginChart series={series} />
+            </Card>
+            <Card title="Spend vs cash revenue" subtitle="Purchasing outflow against sales inflow, last 12 weeks">
+                <SpendVsRevenueChart series={series} />
+            </Card>
+            <Card title="Top products by margin" subtitle={`${PERIODS.find((p) => p.id === data.period)?.label}`}>
+                <MarginBars rows={data.margin.topByMargin} />
+            </Card>
+            <Card title="Inventory value by category" subtitle="Current on-hand valuation">
+                <CategoryBars cats={data.valuation.byCategory} />
+            </Card>
+        </div>
+    );
+}
+
+function Card({ title, subtitle, children }: { title: string; subtitle?: string; children: React.ReactNode }) {
+    return (
+        <div className="bg-white rounded-2xl shadow-lg border-2 border-hackclub-smoke p-5">
+            <h3 className="text-lg font-black text-hackclub-dark">{title}</h3>
+            {subtitle && <p className="text-xs text-hackclub-muted font-bold uppercase tracking-wide mb-3">{subtitle}</p>}
+            {children}
+        </div>
+    );
+}
+
+// Diverging bar chart: margin can go negative, so baseline sits at zero.
+function WeeklyMarginChart({ series }: { series: WeekPoint[] }) {
+    const max = Math.max(1, ...series.map((s) => Math.abs(s.cashMargin)));
+    return (
+        <div className="overflow-x-auto">
+            <div className="flex items-stretch gap-1.5 h-48" style={{ minWidth: `${series.length * 28}px` }}>
+                {series.map((s) => {
+                    const pos = s.cashMargin >= 0;
+                    const h = (Math.abs(s.cashMargin) / max) * 50;
+                    return (
+                        <div key={s.week} className="flex-1 flex flex-col items-center group" style={{ minWidth: '18px' }}
+                            title={`${s.weekStart}: margin ${usd(s.cashMargin)} (rev ${usd(s.cashRevenue)} − COGS ${usd(s.cashCogs)})`}>
+                            <div className="flex-1 w-full flex items-end justify-center">
+                                {pos && <div className="w-full bg-hackclub-green/80 group-hover:bg-hackclub-green rounded-t transition-colors" style={{ height: `${Math.max(2, h)}%` }} />}
+                            </div>
+                            <div className="w-full h-px bg-hackclub-smoke" />
+                            <div className="flex-1 w-full flex items-start justify-center">
+                                {!pos && s.cashMargin < 0 && <div className="w-full bg-hackclub-red/80 group-hover:bg-hackclub-red rounded-b transition-colors" style={{ height: `${Math.max(2, h)}%` }} />}
+                            </div>
+                            <span className="text-[8px] text-hackclub-muted mt-0.5 whitespace-nowrap">{s.weekStart.slice(5)}</span>
+                        </div>
+                    );
+                })}
+            </div>
+        </div>
+    );
+}
+
+// Paired bars: spend (red) vs revenue (blue) per week.
+function SpendVsRevenueChart({ series }: { series: WeekPoint[] }) {
+    const max = Math.max(1, ...series.map((s) => Math.max(s.spend, s.cashRevenue)));
+    return (
+        <div className="overflow-x-auto">
+            <div className="flex items-end gap-1.5 h-48" style={{ minWidth: `${series.length * 28}px` }}>
+                {series.map((s) => (
+                    <div key={s.week} className="flex-1 flex flex-col items-center justify-end" style={{ minWidth: '18px' }}>
+                        <div className="w-full flex items-end justify-center gap-0.5 h-full">
+                            <div className="w-1/2 bg-hackclub-blue/80 hover:bg-hackclub-blue rounded-t transition-colors" style={{ height: `${Math.max(1, (s.cashRevenue / max) * 100)}%` }} title={`${s.weekStart}: revenue ${usd(s.cashRevenue)}`} />
+                            <div className="w-1/2 bg-hackclub-red/70 hover:bg-hackclub-red rounded-t transition-colors" style={{ height: `${Math.max(1, (s.spend / max) * 100)}%` }} title={`${s.weekStart}: spend ${usd(s.spend)}`} />
+                        </div>
+                        <span className="text-[8px] text-hackclub-muted mt-0.5 whitespace-nowrap">{s.weekStart.slice(5)}</span>
+                    </div>
+                ))}
+            </div>
+            <div className="flex gap-4 mt-3 text-xs font-bold text-hackclub-slate">
+                <span className="flex items-center gap-1.5"><span className="w-3 h-3 rounded bg-hackclub-blue/80 inline-block" /> Revenue</span>
+                <span className="flex items-center gap-1.5"><span className="w-3 h-3 rounded bg-hackclub-red/70 inline-block" /> Spend</span>
+            </div>
+        </div>
+    );
+}
+
+function MarginBars({ rows }: { rows: MarginProductRow[] }) {
+    if (!rows.length) return <Empty>No sales in this period.</Empty>;
+    const max = Math.max(1, ...rows.map((r) => Math.abs(r.margin)));
+    return (
+        <div className="space-y-2">
+            {rows.map((r) => (
+                <div key={(r.variantId || r.name)} className="flex items-center gap-2 text-sm">
+                    <div className="w-32 truncate font-medium text-hackclub-dark" title={r.name}>{r.name}</div>
+                    <div className="flex-1 bg-hackclub-snow rounded h-5 overflow-hidden">
+                        <div className={`h-full ${r.margin >= 0 ? 'bg-hackclub-green/80' : 'bg-hackclub-red/80'}`} style={{ width: `${Math.max(2, (Math.abs(r.margin) / max) * 100)}%` }} />
+                    </div>
+                    <div className="w-20 text-right font-mono font-bold text-hackclub-dark">{usd(r.margin)}</div>
+                </div>
+            ))}
+        </div>
+    );
+}
+
+function CategoryBars({ cats }: { cats: Array<{ category: string; value: number; units: number }> }) {
+    if (!cats.length) return <Empty>No costed inventory yet.</Empty>;
+    const max = Math.max(1, ...cats.map((c) => c.value));
+    return (
+        <div className="space-y-2">
+            {cats.map((c) => (
+                <div key={c.category} className="flex items-center gap-2 text-sm">
+                    <div className="w-32 truncate font-medium text-hackclub-dark" title={c.category}>{c.category}</div>
+                    <div className="flex-1 bg-hackclub-snow rounded h-5 overflow-hidden">
+                        <div className="h-full bg-hackclub-blue/80" style={{ width: `${Math.max(2, (c.value / max) * 100)}%` }} title={`${c.units} units`} />
+                    </div>
+                    <div className="w-20 text-right font-mono font-bold text-hackclub-dark">{usd(c.value)}</div>
+                </div>
+            ))}
+        </div>
+    );
+}
+
+function Empty({ children }: { children: React.ReactNode }) {
+    return <div className="py-8 text-center text-hackclub-muted font-bold">{children}</div>;
+}
+
+// ── Valuation table ────────────────────────────────────────────────────────────
+function ValuationPanel({ valuation }: { valuation: Valuation }) {
+    const [showAll, setShowAll] = useState(false);
+    const [uncostedOnly, setUncostedOnly] = useState(false);
+    const rows = useMemo(() => {
+        let r = valuation.rows;
+        if (uncostedOnly) r = r.filter((x) => x.onHand !== null && x.onHand > 0 && !x.costed);
+        return showAll ? r : r.slice(0, 15);
+    }, [valuation.rows, showAll, uncostedOnly]);
+
+    return (
+        <div className="bg-white rounded-2xl shadow-lg border-2 border-hackclub-smoke overflow-hidden mb-6">
+            <div className="flex flex-wrap items-center justify-between gap-3 px-5 py-4 border-b-2 border-hackclub-smoke">
+                <div>
+                    <h3 className="text-lg font-black text-hackclub-dark">Inventory valuation</h3>
+                    <p className="text-xs text-hackclub-muted font-bold uppercase tracking-wide">On-hand units × weighted-avg cost</p>
+                </div>
+                <button type="button" onClick={() => setUncostedOnly((v) => !v)}
+                    className={`px-3 py-1.5 rounded-full text-xs font-bold border-2 transition-colors ${uncostedOnly ? 'bg-hackclub-orange text-white border-hackclub-orange' : 'bg-white text-hackclub-slate border-hackclub-smoke hover:border-hackclub-slate'}`}>
+                    Uncosted only
+                </button>
+            </div>
+            <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                    <thead className="bg-hackclub-snow border-b-2 border-hackclub-smoke">
+                        <tr className="text-left text-hackclub-muted font-black uppercase text-xs">
+                            <th className="px-4 py-3">Product / Variant</th>
+                            <th className="px-4 py-3 text-right">On hand</th>
+                            <th className="px-4 py-3 text-right">Unit cost</th>
+                            <th className="px-4 py-3 text-right">Value</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {rows.length === 0 ? (
+                            <tr><td colSpan={4} className="px-4 py-10 text-center text-hackclub-muted font-bold">No variants{uncostedOnly ? ' are uncosted' : ''}.</td></tr>
+                        ) : rows.map((r) => (
+                            <tr key={r.variantId} className="border-b border-hackclub-smoke last:border-0">
+                                <td className="px-4 py-3">
+                                    <div className="font-bold text-hackclub-dark">{r.productName}</div>
+                                    <div className="text-hackclub-muted">{r.variantName}</div>
+                                </td>
+                                <td className="px-4 py-3 text-right font-mono">{r.onHand === null ? <span className="text-hackclub-muted">∞</span> : r.onHand}</td>
+                                <td className="px-4 py-3 text-right font-mono">
+                                    {r.unitCost === null ? <span className="px-2 py-0.5 rounded-full text-xs font-black bg-hackclub-orange/20 text-hackclub-orange">uncosted</span> : usd(r.unitCost)}
+                                </td>
+                                <td className="px-4 py-3 text-right font-mono font-bold text-hackclub-dark">{r.value > 0 ? usd(r.value) : '—'}</td>
+                            </tr>
+                        ))}
+                    </tbody>
+                    <tfoot>
+                        <tr className="bg-hackclub-snow border-t-2 border-hackclub-smoke font-black">
+                            <td className="px-4 py-3 text-hackclub-dark">Total</td>
+                            <td className="px-4 py-3 text-right font-mono">{valuation.totalUnits.toLocaleString()}</td>
+                            <td />
+                            <td className="px-4 py-3 text-right font-mono text-hackclub-blue">{usd(valuation.totalValue)}</td>
+                        </tr>
+                    </tfoot>
+                </table>
+            </div>
+            {valuation.rows.length > 15 && (
+                <div className="px-5 py-3 border-t border-hackclub-smoke text-center">
+                    <button type="button" onClick={() => setShowAll((v) => !v)} className="text-hackclub-blue hover:underline font-bold text-sm">
+                        {showAll ? 'Show top 15' : `Show all ${valuation.rows.length} variants`}
+                    </button>
+                </div>
+            )}
+        </div>
+    );
+}
+
+// ── Margin breakdown (top + bottom) ──────────────────────────────────────────────
+function MarginPanel({ margin }: { margin: CogsAndMargin }) {
+    return (
+        <div className="bg-white rounded-2xl shadow-lg border-2 border-hackclub-smoke p-5 mb-6">
+            <div className="flex flex-wrap items-center justify-between gap-3 mb-3">
+                <h3 className="text-lg font-black text-hackclub-dark">Margin by product</h3>
+                {margin.estimatedLineShare > 0 && (
+                    <span className="text-xs font-bold text-hackclub-orange bg-hackclub-orange/10 px-3 py-1 rounded-full">
+                        {Math.round(margin.estimatedLineShare * 100)}% of sold lines use estimated cost
+                    </span>
+                )}
+            </div>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                <MarginList title="Best margin" rows={margin.topByMargin} />
+                <MarginList title="Worst margin" rows={margin.bottomByMargin} />
+            </div>
+        </div>
+    );
+}
+
+function MarginList({ title, rows }: { title: string; rows: MarginProductRow[] }) {
+    return (
+        <div>
+            <div className="text-xs font-black uppercase text-hackclub-muted tracking-wide mb-2">{title}</div>
+            {rows.length === 0 ? <Empty>No data.</Empty> : (
+                <table className="w-full text-sm">
+                    <thead>
+                        <tr className="text-left text-hackclub-muted font-bold text-xs">
+                            <th className="py-1">Product</th><th className="py-1 text-right">Units</th><th className="py-1 text-right">Revenue</th><th className="py-1 text-right">Margin</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {rows.map((r) => (
+                            <tr key={r.variantId || r.name} className="border-t border-hackclub-smoke">
+                                <td className="py-1.5 font-medium text-hackclub-dark truncate max-w-[160px]" title={r.name}>{r.name}</td>
+                                <td className="py-1.5 text-right font-mono">{r.unitsSold}</td>
+                                <td className="py-1.5 text-right font-mono">{usd(r.revenue)}</td>
+                                <td className={`py-1.5 text-right font-mono font-bold ${r.margin >= 0 ? 'text-hackclub-green' : 'text-hackclub-red'}`}>{usd(r.margin)}{r.marginPct !== null ? <span className="text-hackclub-muted font-normal"> ({r.marginPct}%)</span> : null}</td>
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            )}
+        </div>
+    );
+}
+
+// ── Weekly report ────────────────────────────────────────────────────────────
+function WeeklyPanel({ onReceived }: { onReceived: () => void }) {
+    const [week, setWeek] = useState<string>(() => new Date().toISOString().slice(0, 10));
+    const [report, setReport] = useState<WeeklyReport | null>(null);
+    const [loading, setLoading] = useState(false);
+    const [err, setErr] = useState<string | null>(null);
+    // onReceived is unused here but kept for symmetry; weekly is read-only.
+    void onReceived;
+
+    const load = useCallback(async (w: string) => {
+        setLoading(true); setErr(null);
+        try {
+            const res = await fetch(`/api/admin/finance/weekly?week=${w}`);
+            if (!res.ok) { setErr('Failed to load weekly report'); return; }
+            setReport(await res.json());
+        } catch { setErr('Failed to load weekly report'); }
+        finally { setLoading(false); }
+    }, []);
+
+    useEffect(() => { load(week); }, [week, load]);
+
+    const shiftWeek = (deltaDays: number) => {
+        const d = new Date(week); d.setDate(d.getDate() + deltaDays); setWeek(d.toISOString().slice(0, 10));
+    };
+
+    return (
+        <div className="bg-white rounded-2xl shadow-lg border-2 border-hackclub-smoke p-5 mb-6">
+            <div className="flex flex-wrap items-center justify-between gap-3 mb-4">
+                <div>
+                    <h3 className="text-lg font-black text-hackclub-dark">Weekly report</h3>
+                    <p className="text-xs text-hackclub-muted font-bold uppercase tracking-wide">{report ? `${report.week} · ${report.weekStart} → ${report.weekEnd}` : 'Loading…'}</p>
+                </div>
+                <div className="flex items-center gap-2">
+                    <button type="button" onClick={() => shiftWeek(-7)} className="px-3 py-1.5 rounded-full text-sm font-bold border-2 border-hackclub-smoke hover:border-hackclub-slate text-hackclub-slate">← Prev</button>
+                    <input type="date" value={week} onChange={(e) => setWeek(e.target.value)} className="rounded-lg border-2 border-hackclub-smoke px-2 py-1 text-sm font-medium focus:outline-none focus:border-hackclub-blue" />
+                    <button type="button" onClick={() => shiftWeek(7)} className="px-3 py-1.5 rounded-full text-sm font-bold border-2 border-hackclub-smoke hover:border-hackclub-slate text-hackclub-slate">Next →</button>
+                    <a href={`/api/admin/finance/weekly/export?week=${week}`} className="px-4 py-1.5 rounded-full text-sm font-bold bg-hackclub-green hover:bg-green-600 text-white transition-colors">Export CSV</a>
+                </div>
+            </div>
+
+            {err && <p className="text-hackclub-red font-bold">{err}</p>}
+            {loading && !report && <Empty>Loading…</Empty>}
+            {report && (
+                <>
+                    <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-7 gap-3 mb-4">
+                        <MiniStat label="Orders" value={String(report.orders)} />
+                        <MiniStat label="Units sold" value={String(report.unitsSold)} />
+                        <MiniStat label="Cash revenue" value={usd(report.cashRevenue)} />
+                        <MiniStat label="COGS" value={usd(report.cashCogs)} />
+                        <MiniStat label="Margin" value={usd(report.cashMargin)} tone={report.cashMargin >= 0 ? 'green' : 'red'} />
+                        <MiniStat label="Units received" value={String(report.unitsReceived)} />
+                        <MiniStat label="Spend" value={usd(report.spend)} tone="red" />
+                    </div>
+                    <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+                        <FlagList title={`Low stock (${report.lowStock.length})`} empty="Nothing low." tone="orange">
+                            {report.lowStock.map((l) => (
+                                <li key={l.variantId} className="flex justify-between gap-2 py-1 border-b border-hackclub-smoke last:border-0">
+                                    <span className="truncate text-hackclub-dark font-medium">{l.productName} · {l.variantName}</span>
+                                    <span className="font-mono font-bold text-hackclub-orange">{l.available ?? '∞'}</span>
+                                </li>
+                            ))}
+                        </FlagList>
+                        <FlagList title={`Dead stock (${report.deadStock.length})`} empty="Nothing stale." tone="red">
+                            {report.deadStock.map((d) => (
+                                <li key={d.variantId} className="flex justify-between gap-2 py-1 border-b border-hackclub-smoke last:border-0">
+                                    <span className="truncate text-hackclub-dark font-medium">{d.productName} · {d.variantName} <span className="text-hackclub-muted">({d.lastSold || 'never sold'})</span></span>
+                                    <span className="font-mono font-bold text-hackclub-red">{usd(d.value)}</span>
+                                </li>
+                            ))}
+                        </FlagList>
+                    </div>
+                </>
+            )}
+        </div>
+    );
+}
+
+function MiniStat({ label, value, tone = 'dark' }: { label: string; value: string; tone?: 'dark' | 'green' | 'red' }) {
+    const c = { dark: 'text-hackclub-dark', green: 'text-hackclub-green', red: 'text-hackclub-red' }[tone];
+    return (
+        <div className="bg-hackclub-snow rounded-xl p-3">
+            <div className="text-[10px] font-black uppercase text-hackclub-muted tracking-wide">{label}</div>
+            <div className={`text-lg font-black mt-0.5 ${c}`}>{value}</div>
+        </div>
+    );
+}
+
+function FlagList({ title, tone, empty, children }: { title: string; tone: 'orange' | 'red'; empty: string; children: React.ReactNode }) {
+    const hasItems = Array.isArray(children) ? children.length > 0 : Boolean(children);
+    const dot = tone === 'orange' ? 'bg-hackclub-orange' : 'bg-hackclub-red';
+    return (
+        <div>
+            <div className="flex items-center gap-2 text-xs font-black uppercase text-hackclub-muted tracking-wide mb-2">
+                <span className={`w-2 h-2 rounded-full ${dot}`} />{title}
+            </div>
+            {hasItems ? <ul className="text-sm max-h-56 overflow-y-auto">{children}</ul> : <Empty>{empty}</Empty>}
+        </div>
+    );
+}
+
+// ── Receiving form + recent receipts ──────────────────────────────────────────
+function ReceivingPanel({ rows, onReceived }: { rows: ValuationRow[]; onReceived: () => void }) {
+    const [variantId, setVariantId] = useState('');
+    const [quantity, setQuantity] = useState('');
+    const [unitCost, setUnitCost] = useState('');
+    const [note, setNote] = useState('');
+    const [submitting, setSubmitting] = useState(false);
+    const [msg, setMsg] = useState<string | null>(null);
+    const [err, setErr] = useState<string | null>(null);
+    const [receipts, setReceipts] = useState<Receipt[]>([]);
+
+    const selected = rows.find((r) => r.variantId === variantId);
+
+    const loadReceipts = useCallback(async () => {
+        try {
+            const res = await fetch('/api/admin/finance/receiving');
+            if (res.ok) setReceipts((await res.json()).receipts || []);
+        } catch { /* best-effort */ }
+    }, []);
+    useEffect(() => { loadReceipts(); }, [loadReceipts]);
+
+    // Prefill the cost field with the variant's current avg cost as a sensible default.
+    useEffect(() => {
+        if (selected && selected.unitCost !== null) setUnitCost(String(selected.unitCost));
+    }, [selected]);
+
+    const submit = async () => {
+        setErr(null); setMsg(null);
+        if (!selected) { setErr('Pick a variant.'); return; }
+        const qty = parseInt(quantity, 10);
+        const cost = parseFloat(unitCost);
+        if (!Number.isFinite(qty) || qty <= 0) { setErr('Quantity must be a positive whole number.'); return; }
+        if (!Number.isFinite(cost) || cost < 0) { setErr('Unit cost must be zero or more.'); return; }
+        setSubmitting(true);
+        // Idempotency key so a double-click can't double-count.
+        const receiptId = `rcpt_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`;
+        try {
+            const res = await fetch('/api/admin/finance/receiving', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ productId: selected.productId, variantId: selected.variantId, quantity: qty, unitCost: cost, note: note.trim() || undefined, receiptId }),
+            });
+            const data = await res.json();
+            if (!res.ok) { setErr(data.error || 'Could not record receipt.'); return; }
+            setMsg(`Received ${qty} × ${selected.productName} · ${selected.variantName}. New avg cost ${usd(data.receipt.avgCostAfter)}.`);
+            setQuantity(''); setNote('');
+            await loadReceipts();
+            onReceived(); // refresh KPIs/valuation
+        } catch {
+            setErr('Could not record receipt.');
+        } finally {
+            setSubmitting(false);
+        }
+    };
+
+    return (
+        <div className="bg-white rounded-2xl shadow-lg border-2 border-hackclub-smoke p-5 mb-6">
+            <h3 className="text-lg font-black text-hackclub-dark">Receive stock</h3>
+            <p className="text-xs text-hackclub-muted font-bold uppercase tracking-wide mb-4">Records a purchase, blends weighted-avg cost, and adds units to stock</p>
+
+            {err && <div className="mb-3 p-3 bg-hackclub-red/10 border-2 border-hackclub-red rounded-xl text-hackclub-red font-bold text-sm">{err}</div>}
+            {msg && <div className="mb-3 p-3 bg-hackclub-green/10 border-2 border-hackclub-green/40 rounded-xl text-hackclub-green font-bold text-sm">{msg}</div>}
+
+            <div className="grid grid-cols-1 md:grid-cols-12 gap-3 items-end">
+                <div className="md:col-span-5">
+                    <label className="block text-xs font-black uppercase text-hackclub-muted mb-1">Variant</label>
+                    <select value={variantId} onChange={(e) => setVariantId(e.target.value)}
+                        className="w-full px-3 py-2 border-2 border-hackclub-smoke rounded-lg focus:outline-none focus:border-hackclub-blue text-hackclub-dark font-medium">
+                        <option value="">Select a variant…</option>
+                        {rows.map((r) => (
+                            <option key={r.variantId} value={r.variantId}>
+                                {r.productName} · {r.variantName}{r.onHand !== null ? ` (${r.onHand} on hand)` : ''}{r.unitCost !== null ? ` · ${usd(r.unitCost)}` : ' · uncosted'}
+                            </option>
+                        ))}
+                    </select>
+                </div>
+                <div className="md:col-span-2">
+                    <label className="block text-xs font-black uppercase text-hackclub-muted mb-1">Quantity</label>
+                    <input type="number" min={1} value={quantity} onChange={(e) => setQuantity(e.target.value)} placeholder="0"
+                        className="w-full px-3 py-2 border-2 border-hackclub-smoke rounded-lg focus:outline-none focus:border-hackclub-blue text-hackclub-dark font-mono" />
+                </div>
+                <div className="md:col-span-2">
+                    <label className="block text-xs font-black uppercase text-hackclub-muted mb-1">Unit cost ($)</label>
+                    <input type="number" min={0} step="0.01" value={unitCost} onChange={(e) => setUnitCost(e.target.value)} placeholder="0.00"
+                        className="w-full px-3 py-2 border-2 border-hackclub-smoke rounded-lg focus:outline-none focus:border-hackclub-blue text-hackclub-dark font-mono" />
+                </div>
+                <div className="md:col-span-3">
+                    <label className="block text-xs font-black uppercase text-hackclub-muted mb-1">Note (optional)</label>
+                    <input type="text" value={note} onChange={(e) => setNote(e.target.value)} placeholder="PO #, supplier…"
+                        className="w-full px-3 py-2 border-2 border-hackclub-smoke rounded-lg focus:outline-none focus:border-hackclub-blue text-hackclub-dark font-medium" />
+                </div>
+            </div>
+            <div className="mt-3 flex items-center justify-between gap-3 flex-wrap">
+                <p className="text-sm text-hackclub-slate font-medium">
+                    {selected && quantity && unitCost && Number(quantity) > 0
+                        ? <>Total spend <span className="font-bold text-hackclub-dark">{usd(parseInt(quantity, 10) * parseFloat(unitCost || '0'))}</span>{selected.unitCost !== null && <> · current avg {usd(selected.unitCost)}</>}</>
+                        : 'Pick a variant, quantity, and unit cost.'}
+                </p>
+                <button type="button" onClick={submit} disabled={submitting}
+                    className="px-6 py-2.5 rounded-full font-bold text-white bg-hackclub-blue hover:bg-blue-600 transition-colors disabled:opacity-50">
+                    {submitting ? 'Recording…' : 'Receive stock'}
+                </button>
+            </div>
+
+            {receipts.length > 0 && (
+                <div className="mt-6">
+                    <div className="text-xs font-black uppercase text-hackclub-muted tracking-wide mb-2">Recent receipts</div>
+                    <div className="overflow-x-auto">
+                        <table className="w-full text-sm">
+                            <thead>
+                                <tr className="text-left text-hackclub-muted font-bold text-xs border-b border-hackclub-smoke">
+                                    <th className="py-2">When</th><th className="py-2">Product / Variant</th><th className="py-2 text-right">Qty</th><th className="py-2 text-right">Unit cost</th><th className="py-2 text-right">Total</th><th className="py-2 text-right">New avg</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {receipts.slice(0, 20).map((r) => (
+                                    <tr key={r.id} className="border-b border-hackclub-smoke last:border-0">
+                                        <td className="py-2 text-hackclub-muted whitespace-nowrap">{new Date(r.receivedAt).toLocaleDateString()}</td>
+                                        <td className="py-2 font-medium text-hackclub-dark">{r.productName} · {r.variantName}{r.note ? <span className="text-hackclub-muted"> — {r.note}</span> : null}</td>
+                                        <td className="py-2 text-right font-mono">{r.quantity}</td>
+                                        <td className="py-2 text-right font-mono">{usd(r.unitCost)}</td>
+                                        <td className="py-2 text-right font-mono">{usd(r.totalCost)}</td>
+                                        <td className="py-2 text-right font-mono font-bold text-hackclub-dark">{usd(r.avgCostAfter)}</td>
+                                    </tr>
+                                ))}
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/app/admin/inventory/page.tsx
+++ b/src/app/admin/inventory/page.tsx
@@ -148,7 +148,7 @@ export default function InventoryAdmin() {
                         </button>
                     </div>
                     <p className="text-lg text-hackclub-slate font-medium mb-6">
-                        Stock is tracked per variant. Leave a stock field blank for unlimited. Airtable is the source of truth — edits here also update the product and re-sync to Airtable.
+                        Stock is tracked per variant. Leave a stock field blank for unlimited. Airtable is the source of truth — edits here also update the product and re-sync to Airtable. For cost, valuation, and margins, see <Link href="/admin/finance" className="text-hackclub-blue hover:underline font-bold">Finance</Link>.
                     </p>
 
                     <div className="mb-6">

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -238,6 +238,23 @@ export default function AdminDashboard() {
                             </Link>
                         </motion.div>
 
+                        {/* Finance */}
+                        <motion.div
+                            initial={{ opacity: 0, y: 20 }}
+                            animate={{ opacity: 1, y: 0 }}
+                            transition={{ delay: 0.52 }}
+                        >
+                            <Link href="/admin/finance">
+                                <div className="bg-white rounded-2xl shadow-lg border-2 border-hackclub-smoke p-6 hover:shadow-xl hover:border-hackclub-green transition-all cursor-pointer group">
+                                    <div className="w-12 h-12 bg-hackclub-green/10 rounded-lg flex items-center justify-center mb-4 group-hover:bg-hackclub-green/20 transition-colors">
+                                        <Icon glyph="bag" size={24} style={{ color: 'var(--hackclub-green, #33d6a6)' }} />
+                                    </div>
+                                    <h3 className="text-xl font-black text-hackclub-dark mb-2">Finance</h3>
+                                    <p className="text-hackclub-slate text-sm">Inventory value, cost of goods, margins, weekly reports</p>
+                                </div>
+                            </Link>
+                        </motion.div>
+
                         {/* Audit Log */}
                         <motion.div
                             initial={{ opacity: 0, y: 20 }}

--- a/src/app/admin/products/page.tsx
+++ b/src/app/admin/products/page.tsx
@@ -98,7 +98,8 @@ export default function ProductsAdmin() {
             color: '',
             image_url: '',
             stock: '',
-            weightOz: ''
+            weightOz: '',
+            unitCost: ''
         }],
         shippingOptions: [{ id: '', country: '', cost: '', costPoints: '' }],
         checkoutFields: [] as FormCheckoutField[],
@@ -183,6 +184,7 @@ export default function ProductsAdmin() {
                         image_url: v.image_url,
                         stock: v.stock,
                         weightOz: v.weightOz,
+                        unitCost: v.unitCost,
                         priceCash: v.priceCash,
                         pricePoints: v.pricePoints,
                     })),
@@ -222,7 +224,8 @@ export default function ProductsAdmin() {
                     color: '',
                     image_url: '',
                     stock: '',
-                    weightOz: ''
+                    weightOz: '',
+                    unitCost: ''
                 }],
                 shippingOptions: [{ id: '', country: '', cost: '', costPoints: '' }],
                 checkoutFields: [],
@@ -257,6 +260,7 @@ export default function ProductsAdmin() {
                 image_url: v.image_url || '',
                 stock: v.stock?.toString() || '',
                 weightOz: (v as any).weightOz?.toString() || '',
+                unitCost: (v as any).unitCost != null ? String((v as any).unitCost) : '',
             };
         });
 
@@ -276,7 +280,8 @@ export default function ProductsAdmin() {
                 color: '',
                 image_url: '',
                 stock: '',
-                weightOz: ''
+                weightOz: '',
+                unitCost: ''
             }],
             shippingOptions: (product.shippingOptions || []).map(s => ({
                 id: s.id,
@@ -307,7 +312,8 @@ export default function ProductsAdmin() {
                 color: '',
                 image_url: '',
                 stock: '',
-                weightOz: ''
+                weightOz: '',
+                unitCost: ''
             }],
             shippingOptions: [{ id: '', country: '', cost: '', costPoints: '' }],
             checkoutFields: [],
@@ -566,6 +572,20 @@ export default function ProductsAdmin() {
                                                             }}
                                                             className="px-3 py-2 border-2 border-hackclub-smoke rounded-lg focus:outline-none focus:border-hackclub-red text-hackclub-dark font-medium"
                                                         />
+                                                        <input
+                                                            type="number"
+                                                            step="0.01"
+                                                            min={0}
+                                                            placeholder="Unit cost ($)"
+                                                            title="What we pay per unit (USD) — drives inventory valuation and cost of goods. Recording a stock receipt in Finance updates this to a weighted average. Leave blank if unknown."
+                                                            value={variant.unitCost}
+                                                            onChange={(e) => {
+                                                                const newVariants = [...formData.variants];
+                                                                newVariants[idx].unitCost = e.target.value;
+                                                                setFormData({ ...formData, variants: newVariants });
+                                                            }}
+                                                            className="px-3 py-2 border-2 border-hackclub-smoke rounded-lg focus:outline-none focus:border-hackclub-red text-hackclub-dark font-medium"
+                                                        />
                                                         {formData.variants.length > 1 && (
                                                             <button
                                                                 type="button"
@@ -595,7 +615,8 @@ export default function ProductsAdmin() {
                                                         color: '',
                                                         image_url: '',
                                                         stock: '',
-                                                        weightOz: ''
+                                                        weightOz: '',
+                                                        unitCost: ''
                                                     }]
                                                 })}
                                                 className="w-full px-4 py-2 border-2 border-dashed border-hackclub-green text-hackclub-green font-bold rounded-lg hover:bg-hackclub-green/10 transition-colors"

--- a/src/app/api/admin/finance/overview/route.ts
+++ b/src/app/api/admin/finance/overview/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '../../../auth/[...nextauth]/route';
+import { requireAdminPermission } from '../../../../../lib/adminAuth';
+import { getFinanceOverview, Period } from '../../../../../lib/finance';
+
+const VALID: Period[] = ['week', 'month', 'year', 'all'];
+
+/** Finance dashboard data: valuation + COGS/margin + spend + weekly series. */
+export async function GET(request: Request) {
+    const session = await getServerSession(authOptions);
+    const can = await requireAdminPermission(session, 'canManageFinance');
+    if (!can.allowed) return NextResponse.json({ error: 'Unauthorized' }, { status: 403 });
+
+    try {
+        const { searchParams } = new URL(request.url);
+        const raw = searchParams.get('period') || 'month';
+        const period: Period = (VALID as string[]).includes(raw) ? (raw as Period) : 'month';
+        const overview = await getFinanceOverview(period);
+        return NextResponse.json(overview);
+    } catch (err) {
+        console.error('[finance/overview] failed:', err instanceof Error ? err.message : err);
+        return NextResponse.json({ error: 'Failed to load finance overview' }, { status: 500 });
+    }
+}

--- a/src/app/api/admin/finance/receiving/route.ts
+++ b/src/app/api/admin/finance/receiving/route.ts
@@ -1,0 +1,65 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '../../../auth/[...nextauth]/route';
+import { requireAdminPermission } from '../../../../../lib/adminAuth';
+import { receiveStock, readReceipts, readVariantReceipts } from '../../../../../lib/costing';
+
+/**
+ * Stock receiving (purchase) ledger.
+ *   GET  ?variantId=…   → that variant's receipt history (or recent across all).
+ *   POST { productId, variantId, quantity, unitCost, note?, receiptId? }
+ *        → record a receipt: blends the weighted-average cost, bumps stock,
+ *          audits, and re-mirrors to Airtable.
+ */
+export async function GET(request: Request) {
+    const session = await getServerSession(authOptions);
+    const can = await requireAdminPermission(session, 'canManageFinance');
+    if (!can.allowed) return NextResponse.json({ error: 'Unauthorized' }, { status: 403 });
+
+    try {
+        const { searchParams } = new URL(request.url);
+        const variantId = searchParams.get('variantId');
+        const receipts = variantId ? await readVariantReceipts(variantId, 100) : await readReceipts(100);
+        return NextResponse.json({ receipts });
+    } catch (err) {
+        console.error('[finance/receiving] GET failed:', err instanceof Error ? err.message : err);
+        return NextResponse.json({ error: 'Failed to load receipts' }, { status: 500 });
+    }
+}
+
+export async function POST(request: Request) {
+    const session = await getServerSession(authOptions);
+    const can = await requireAdminPermission(session, 'canManageFinance');
+    if (!can.allowed) return NextResponse.json({ error: 'Unauthorized' }, { status: 403 });
+
+    let body: {
+        productId?: string;
+        variantId?: string;
+        quantity?: number | string;
+        unitCost?: number | string;
+        note?: string;
+        receiptId?: string;
+    };
+    try {
+        body = await request.json();
+    } catch {
+        return NextResponse.json({ error: 'Invalid request body' }, { status: 400 });
+    }
+
+    const result = await receiveStock({
+        productId: String(body.productId || ''),
+        variantId: String(body.variantId || ''),
+        quantity: Number(body.quantity),
+        unitCost: Number(body.unitCost),
+        note: body.note,
+        receiptId: body.receiptId,
+        actorId: session?.user?.id || 'unknown',
+        actorEmail: session?.user?.email || undefined,
+    });
+
+    if (!result.ok) {
+        const code = result.error === 'Product not found' || result.error === 'Variant not found' ? 404 : 400;
+        return NextResponse.json({ error: result.error }, { status: code });
+    }
+    return NextResponse.json(result);
+}

--- a/src/app/api/admin/finance/weekly/export/route.ts
+++ b/src/app/api/admin/finance/weekly/export/route.ts
@@ -1,0 +1,75 @@
+import { getServerSession } from 'next-auth';
+import { NextResponse } from 'next/server';
+import { authOptions } from '../../../../auth/[...nextauth]/route';
+import { requireAdminPermission } from '../../../../../../lib/adminAuth';
+import { getWeeklyReport } from '../../../../../../lib/finance';
+
+/**
+ * Weekly finance report as a CSV download. Same formula-injection-safe escaping
+ * the orders export uses: a leading =,+,-,@ is prefixed with ' so a spreadsheet
+ * treats the cell as text, never a formula.
+ */
+function esc(v: unknown): string {
+    let s = String(v ?? '');
+    if (/^[=+\-@]/.test(s)) s = `'${s}`;
+    return `"${s.replace(/"/g, '""')}"`;
+}
+
+export async function GET(request: Request) {
+    const session = await getServerSession(authOptions);
+    const can = await requireAdminPermission(session, 'canManageFinance');
+    if (!can.allowed) return NextResponse.json({ error: 'Unauthorized' }, { status: 403 });
+
+    try {
+        const { searchParams } = new URL(request.url);
+        const weekParam = searchParams.get('week');
+        const date = weekParam ? new Date(weekParam) : new Date();
+        const when = Number.isNaN(date.getTime()) ? new Date() : date;
+        const r = await getWeeklyReport(when);
+
+        const lines: string[][] = [
+            ['Hack Club Shop — Weekly Finance Report'],
+            ['Week', r.week, `${r.weekStart} to ${r.weekEnd}`],
+            [],
+            ['Sales'],
+            ['Metric', 'Value'],
+            ['Orders', String(r.orders)],
+            ['Units sold', String(r.unitsSold)],
+            ['Cash revenue (USD)', r.cashRevenue.toFixed(2)],
+            ['Cash COGS (USD)', r.cashCogs.toFixed(2)],
+            ['Cash gross margin (USD)', r.cashMargin.toFixed(2)],
+            ['Cash gross margin (%)', r.cashMarginPct === null ? 'n/a' : r.cashMarginPct.toFixed(1)],
+            ['Points COGS (USD)', r.pointsCogs.toFixed(2)],
+            ['Points spent', String(r.pointsSpent)],
+            [],
+            ['Purchasing'],
+            ['Receipts', String(r.receiptCount)],
+            ['Units received', String(r.unitsReceived)],
+            ['Spend (USD)', r.spend.toFixed(2)],
+            [],
+            ['Position at report time'],
+            ['Ending inventory value (USD)', r.endingInventoryValue.toFixed(2)],
+            ['Uncosted variants', String(r.uncostedVariants)],
+            [],
+            ['Low stock (≤5 available)'],
+            ['Product', 'Variant', 'Available'],
+            ...r.lowStock.map((l) => [l.productName, l.variantName, l.available === null ? '∞' : String(l.available)]),
+            [],
+            [`Dead stock (no sale in 8 weeks, holding value)`],
+            ['Product', 'Variant', 'On hand', 'Value (USD)', 'Last sold'],
+            ...r.deadStock.map((d) => [d.productName, d.variantName, String(d.onHand), d.value.toFixed(2), d.lastSold || 'never']),
+        ];
+
+        const csv = lines.map((row) => row.map(esc).join(',')).join('\n');
+        return new NextResponse(csv, {
+            status: 200,
+            headers: {
+                'Content-Type': 'text/csv;charset=utf-8;',
+                'Content-Disposition': `attachment; filename="finance-week-${r.week}.csv"`,
+            },
+        });
+    } catch (err) {
+        console.error('[finance/weekly/export] failed:', err instanceof Error ? err.message : err);
+        return NextResponse.json({ error: 'Failed to export weekly report' }, { status: 500 });
+    }
+}

--- a/src/app/api/admin/finance/weekly/route.ts
+++ b/src/app/api/admin/finance/weekly/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '../../../auth/[...nextauth]/route';
+import { requireAdminPermission } from '../../../../../lib/adminAuth';
+import { getWeeklyReport } from '../../../../../lib/finance';
+
+/**
+ * Weekly finance report (JSON). `?week=YYYY-MM-DD` selects any date inside the
+ * desired ISO week; omit for the current week. The CSV form lives at
+ * /api/admin/finance/weekly/export.
+ */
+export async function GET(request: Request) {
+    const session = await getServerSession(authOptions);
+    const can = await requireAdminPermission(session, 'canManageFinance');
+    if (!can.allowed) return NextResponse.json({ error: 'Unauthorized' }, { status: 403 });
+
+    try {
+        const { searchParams } = new URL(request.url);
+        const weekParam = searchParams.get('week');
+        const date = weekParam ? new Date(weekParam) : new Date();
+        const when = Number.isNaN(date.getTime()) ? new Date() : date;
+        const report = await getWeeklyReport(when);
+        return NextResponse.json(report);
+    } catch (err) {
+        console.error('[finance/weekly] failed:', err instanceof Error ? err.message : err);
+        return NextResponse.json({ error: 'Failed to build weekly report' }, { status: 500 });
+    }
+}

--- a/src/app/api/admin/products/[id]/route.ts
+++ b/src/app/api/admin/products/[id]/route.ts
@@ -70,6 +70,20 @@ export async function PUT(
                 weightOz: v.weightOz != null && v.weightOz !== '' ? parseFloat(v.weightOz) : undefined,
             };
 
+            // Unit cost: a submitted value wins; otherwise preserve any existing
+            // cost on the variant (the receiving ledger may have set a weighted
+            // average we don't want a plain product edit to wipe). Matched by
+            // index, then by id as a fallback if the order shifted.
+            const submittedCost = v.unitCost != null && v.unitCost !== '' && !Number.isNaN(parseFloat(v.unitCost))
+                ? Math.max(0, parseFloat(v.unitCost))
+                : undefined;
+            const priorVariant = product.variants?.[idx]?.variant_id === variant.variant_id
+                ? product.variants?.[idx]
+                : (product.variants || []).find((pv: any) => pv.variant_id === variant.variant_id || pv.id === variant.id);
+            const priorCost = (priorVariant as any)?.unitCost;
+            if (submittedCost !== undefined) variant.unitCost = submittedCost;
+            else if (typeof priorCost === 'number') variant.unitCost = priorCost;
+
             if (cash !== undefined && cash > 0) variant.price_cash = cash;
             if (points !== undefined && points > 0) variant.price_points = points;
 

--- a/src/app/api/admin/products/route.ts
+++ b/src/app/api/admin/products/route.ts
@@ -91,6 +91,7 @@ export async function POST(request: Request) {
                     image_url: v.image_url,
                     stock: v.stock ? parseInt(v.stock) : undefined,
                     weightOz: v.weightOz != null && v.weightOz !== '' ? parseFloat(v.weightOz) : undefined,
+                    unitCost: v.unitCost != null && v.unitCost !== '' && !Number.isNaN(parseFloat(v.unitCost)) ? Math.max(0, parseFloat(v.unitCost)) : undefined,
                 };
 
                 if (cash !== undefined && cash > 0) variant.price_cash = cash;

--- a/src/app/api/checkout/stripe/route.ts
+++ b/src/app/api/checkout/stripe/route.ts
@@ -180,6 +180,9 @@ export async function POST(request: Request) {
                 price: i.price,
                 quantity: i.quantity,
                 thumbnail_url: i.thumbnail_url,
+                // Finance: capture variant + cost basis at sale time for COGS.
+                variantId: i.variantId,
+                unitCost: i.unitCost,
             })),
             subtotal: itemsCashTotal,
             pointsRequired: 0,

--- a/src/app/api/orders/route.ts
+++ b/src/app/api/orders/route.ts
@@ -187,6 +187,9 @@ export async function POST(request: Request) {
                 price: item.price,
                 quantity: item.quantity,
                 thumbnail_url: item.thumbnail_url,
+                // Finance: capture variant + cost basis at sale time for COGS.
+                variantId: item.variantId,
+                unitCost: item.unitCost,
             })),
             subtotal: 0,
             pointsRequired: verifiedPointsTotal,

--- a/src/lib/auditLog.ts
+++ b/src/lib/auditLog.ts
@@ -30,7 +30,8 @@ export type AuditAction =
     | 'order.ship'
     | 'points.grant'
     | 'points.deduct'
-    | 'inventory.adjust';
+    | 'inventory.adjust'
+    | 'inventory.receive';
 
 export interface AuditEntry {
     id: string;

--- a/src/lib/costing.ts
+++ b/src/lib/costing.ts
@@ -1,0 +1,256 @@
+/**
+ * Costing: the receiving (purchase) ledger and weighted-average cost engine.
+ *
+ * This is the FINANCE layer's write side. The operational unit layer
+ * (`src/lib/inventory.ts`) answers "how many can we sell"; this answers "how much
+ * did we pay for it". Read `docs/FINANCE.md` for the model.
+ *
+ * When stock is received we:
+ *   1. write an append-only `Receipt` (who/what/how many/at what cost/when),
+ *   2. recompute the variant's WEIGHTED-AVERAGE unit cost from the prior on-hand
+ *      units+cost and the newly-received units+cost, and store it back on the
+ *      product variant (`variant.unitCost`),
+ *   3. bump the unit stock through the same product record + inventory cache the
+ *      admin quick-adjust uses, so the two layers never drift,
+ *   4. record an audit entry and re-mirror the product to Airtable.
+ *
+ * Everything is fire-and-forget safe like inventory/email/airtableMirror: a Redis
+ * or Airtable hiccup degrades gracefully and never throws into a caller. The one
+ * guard that matters for correctness is idempotency — a double-submitted receipt
+ * must not double-count stock or double-blend cost (see `receiveStock`).
+ */
+
+import { Redis } from '@upstash/redis';
+import { Product } from '../types/Admin';
+import { setStock } from './inventory';
+import { mirrorProduct } from './airtableMirror';
+import { recordAudit } from './auditLog';
+
+const redis = new Redis({
+    url: process.env.UPSTASH_REDIS_REST_URL!,
+    token: process.env.UPSTASH_REDIS_REST_TOKEN!,
+});
+
+const LEDGER_KEY = 'receipts:log';            // capped list, newest first (JSON strings)
+const LEDGER_MAX = 2000;
+const variantIndexKey = (variantId: string) => `receipts:variant:${variantId}`;
+const claimKey = (receiptId: string) => `receipts:claim:${receiptId}`;
+
+/** A single stock-received (purchase) event. Append-only. */
+export interface Receipt {
+    id: string;
+    productId: string;
+    productName: string;
+    variantId: string;
+    variantName: string;
+    quantity: number;        // units received (> 0)
+    unitCost: number;        // USD paid per unit on THIS receipt
+    totalCost: number;       // quantity * unitCost, USD
+    // The variant's resulting state after this receipt, for an auditable trail.
+    avgCostAfter: number;    // weighted-average unit cost after blending this in
+    stockAfter: number | null;
+    note?: string;
+    actorId: string;
+    actorEmail?: string;
+    receivedAt: string;      // ISO
+}
+
+export interface ReceiveInput {
+    productId: string;
+    variantId: string;
+    quantity: number;
+    unitCost: number;
+    note?: string;
+    actorId: string;
+    actorEmail?: string;
+    /** Client-supplied idempotency key so a double-submit can't double-count. */
+    receiptId?: string;
+}
+
+export type ReceiveResult =
+    | { ok: true; receipt: Receipt; duplicate?: false }
+    | { ok: true; duplicate: true; receipt: Receipt }
+    | { ok: false; error: string };
+
+/**
+ * Weighted-average blend. newAvg = (oldUnits*oldAvg + recvUnits*recvCost) /
+ * (oldUnits + recvUnits). Guards div-by-zero and a missing/zero prior average
+ * (untracked or never-costed variant → the received cost simply becomes the avg).
+ */
+export function blendCost(
+    oldUnits: number,
+    oldAvg: number | undefined,
+    recvUnits: number,
+    recvCost: number,
+): number {
+    const ou = Number.isFinite(oldUnits) && oldUnits > 0 ? oldUnits : 0;
+    const oa = typeof oldAvg === 'number' && oldAvg >= 0 ? oldAvg : 0;
+    const ru = Number.isFinite(recvUnits) && recvUnits > 0 ? recvUnits : 0;
+    const rc = Number.isFinite(recvCost) && recvCost >= 0 ? recvCost : 0;
+    const totalUnits = ou + ru;
+    if (totalUnits <= 0) return rc; // nothing to weight by → fall back to received cost
+    // If there was no prior cost basis, don't let phantom $0 units drag the avg down:
+    // blend only against units that actually had a known cost.
+    const oldValue = oa > 0 ? ou * oa : 0;
+    const weightedUnits = oa > 0 ? ou + ru : ru;
+    if (weightedUnits <= 0) return rc;
+    const blended = (oldValue + ru * rc) / weightedUnits;
+    return Math.round(blended * 10000) / 10000; // 4dp, avoid float drift
+}
+
+/**
+ * Record a stock receipt. Updates the variant's weighted-average cost and unit
+ * stock, writes the ledger entry, audits, and re-mirrors to Airtable.
+ *
+ * Idempotent: the first call for a given `receiptId` does the work and claims the
+ * id (Redis SET NX, mirroring `claimOrderSettlement`); a duplicate delivery sees
+ * the claim already taken and returns the stored receipt without re-applying the
+ * stock/cost change.
+ */
+export async function receiveStock(input: ReceiveInput): Promise<ReceiveResult> {
+    const quantity = Math.floor(Number(input.quantity));
+    const unitCost = Number(input.unitCost);
+    if (!input.productId || !input.variantId) return { ok: false, error: 'productId and variantId are required' };
+    if (!Number.isFinite(quantity) || quantity <= 0) return { ok: false, error: 'Quantity must be a positive whole number' };
+    if (!Number.isFinite(unitCost) || unitCost < 0) return { ok: false, error: 'Unit cost must be zero or more' };
+
+    const receiptId = input.receiptId && /^[A-Za-z0-9_-]{1,64}$/.test(input.receiptId)
+        ? input.receiptId
+        : `rcpt_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`;
+
+    // Idempotency claim. On a Redis error we fall through and proceed (fail open),
+    // matching claimOrderSettlement — the worst case of a missed claim is a rare
+    // double-count, far less bad than refusing a legitimate receipt.
+    let claimed = true;
+    try {
+        const res = await redis.set(claimKey(receiptId), Date.now(), { nx: true, ex: 60 * 60 * 24 * 30 });
+        claimed = res === 'OK';
+    } catch (err) {
+        console.error('[costing] claim failed (proceeding):', err instanceof Error ? err.message : err);
+    }
+    if (!claimed) {
+        // Already applied — return the stored receipt so the caller can show it.
+        const existing = await findReceiptById(receiptId);
+        if (existing) return { ok: true, duplicate: true, receipt: existing };
+        // Claimed but no stored receipt found (shouldn't normally happen). Treat as
+        // a benign duplicate rather than re-applying.
+        return { ok: false, error: 'Duplicate receipt' };
+    }
+
+    const product = await redis.get<Product>(`product:${input.productId}`);
+    if (!product) return { ok: false, error: 'Product not found' };
+
+    const idx = (product.variants || []).findIndex(
+        (v) => String(v.variant_id || v.id) === String(input.variantId),
+    );
+    if (idx < 0) return { ok: false, error: 'Variant not found' };
+    const variant = product.variants[idx];
+
+    // Prior on-hand units we blend against. A variant with no stock number is
+    // "untracked/unlimited" — there's no unit base to weight by, so the received
+    // cost simply becomes the new average (blendCost handles oldUnits=0).
+    const priorStock = typeof variant.stock === 'number' ? variant.stock : 0;
+    const priorAvg = typeof variant.unitCost === 'number' ? variant.unitCost : undefined;
+    const newAvg = blendCost(priorStock, priorAvg, quantity, unitCost);
+
+    // Only bump a real stock number. If the variant was untracked (unlimited), we
+    // leave it untracked rather than silently converting it to a counted variant —
+    // receiving cost data shouldn't change the sell-side availability model.
+    const trackingStock = typeof variant.stock === 'number';
+    const stockAfter = trackingStock ? priorStock + quantity : null;
+
+    product.variants[idx] = {
+        ...variant,
+        unitCost: newAvg,
+        ...(trackingStock ? { stock: stockAfter as number } : {}),
+    };
+    product.updatedAt = new Date();
+
+    try {
+        await redis.set(`product:${input.productId}`, product);
+    } catch (err) {
+        console.error('[costing] product save failed:', err instanceof Error ? err.message : err);
+        return { ok: false, error: 'Could not save product' };
+    }
+
+    // Keep the inventory unit cache in step with the new base stock (only when tracked).
+    if (trackingStock) await setStock(input.variantId, stockAfter);
+
+    const receipt: Receipt = {
+        id: receiptId,
+        productId: input.productId,
+        productName: product.name,
+        variantId: input.variantId,
+        variantName: variant.name,
+        quantity,
+        unitCost: Math.round(unitCost * 100) / 100,
+        totalCost: Math.round(quantity * unitCost * 100) / 100,
+        avgCostAfter: newAvg,
+        stockAfter,
+        note: input.note?.slice(0, 500) || undefined,
+        actorId: input.actorId,
+        actorEmail: input.actorEmail,
+        receivedAt: new Date().toISOString(),
+    };
+
+    try {
+        await redis.lpush(LEDGER_KEY, JSON.stringify(receipt));
+        await redis.ltrim(LEDGER_KEY, 0, LEDGER_MAX - 1);
+        await redis.lpush(variantIndexKey(input.variantId), JSON.stringify(receipt));
+        await redis.ltrim(variantIndexKey(input.variantId), 0, 199);
+    } catch (err) {
+        // Ledger write is best-effort; the stock/cost change already landed.
+        console.error('[costing] ledger write failed:', err instanceof Error ? err.message : err);
+    }
+
+    void mirrorProduct(product);
+    void recordAudit({
+        action: 'inventory.receive',
+        actorId: input.actorId,
+        actorEmail: input.actorEmail,
+        target: input.variantId,
+        summary: `Received ${quantity} × "${product.name} / ${variant.name}" @ $${unitCost.toFixed(2)} → avg cost $${newAvg.toFixed(2)}${stockAfter !== null ? `, stock ${stockAfter}` : ''}`,
+        metadata: { receiptId, productId: input.productId, quantity, unitCost, avgCostAfter: newAvg, stockAfter },
+    });
+
+    return { ok: true, receipt };
+}
+
+function parseReceipt(raw: string | Receipt | null): Receipt | null {
+    if (!raw) return null;
+    if (typeof raw === 'string') {
+        try {
+            return JSON.parse(raw) as Receipt;
+        } catch {
+            return null;
+        }
+    }
+    return raw as Receipt; // Upstash may auto-deserialize
+}
+
+/** Most recent receipts across all variants (newest first). */
+export async function readReceipts(limit = 100): Promise<Receipt[]> {
+    try {
+        const raw = await redis.lrange<string | Receipt>(LEDGER_KEY, 0, Math.max(0, limit - 1));
+        return raw.map(parseReceipt).filter((r): r is Receipt => Boolean(r && r.id));
+    } catch (err) {
+        console.error('[costing] readReceipts failed:', err instanceof Error ? err.message : err);
+        return [];
+    }
+}
+
+/** Receipt history for a single variant (newest first). */
+export async function readVariantReceipts(variantId: string, limit = 100): Promise<Receipt[]> {
+    try {
+        const raw = await redis.lrange<string | Receipt>(variantIndexKey(variantId), 0, Math.max(0, limit - 1));
+        return raw.map(parseReceipt).filter((r): r is Receipt => Boolean(r && r.id));
+    } catch (err) {
+        console.error('[costing] readVariantReceipts failed:', err instanceof Error ? err.message : err);
+        return [];
+    }
+}
+
+async function findReceiptById(id: string): Promise<Receipt | null> {
+    const recent = await readReceipts(LEDGER_MAX);
+    return recent.find((r) => r.id === id) || null;
+}

--- a/src/lib/finance.ts
+++ b/src/lib/finance.ts
@@ -1,0 +1,614 @@
+/**
+ * Finance: read-only aggregation over orders, products, and the receiving ledger.
+ *
+ * This is the FINANCE layer's read side — everything the finance dashboard and
+ * weekly report show. It never mutates anything and is fully fire-and-forget
+ * safe: any Redis hiccup degrades to empty/zero rather than throwing. Read
+ * `docs/FINANCE.md` for the costing model and the known approximations.
+ *
+ * Definitions used throughout:
+ *   - On-hand units      = variant.stock (what we PHYSICALLY hold, incl. reserved).
+ *   - Inventory value    = Σ on-hand units × variant.unitCost (weighted-avg cost).
+ *   - Line COGS          = quantity × (line.unitCost captured at sale, else the
+ *                          variant's current cost as an "estimated" fallback).
+ *   - Cash revenue       = guest/Stripe order totalAmount (USD). Points orders
+ *                          have $0 cash revenue but still incur COGS — we surface
+ *                          cash margin and points-fulfillment cost separately so a
+ *                          heavy points week doesn't read as a giant loss.
+ *   - Test orders (isTest) are excluded from every aggregate, matching the stats route.
+ */
+
+import { Redis } from '@upstash/redis';
+import { Order } from '../types/Order';
+import { Product, ProductVariant } from '../types/Admin';
+import { getVariantStocks } from './inventory';
+import { readReceipts, Receipt } from './costing';
+
+const redis = new Redis({
+    url: process.env.UPSTASH_REDIS_REST_URL!,
+    token: process.env.UPSTASH_REDIS_REST_TOKEN!,
+});
+
+export type Period = 'week' | 'month' | 'year' | 'all';
+
+const round2 = (n: number) => Math.round(n * 100) / 100;
+
+// ── Loading ──────────────────────────────────────────────────────────────────
+
+/** All non-test orders across both Redis layouts (student arrays + guest singles). */
+export async function loadAllOrders(): Promise<Order[]> {
+    const orders: Order[] = [];
+    try {
+        const studentKeys = await redis.keys('user:*:orders');
+        for (const key of studentKeys) {
+            const arr = await redis.get<Order[]>(key);
+            if (Array.isArray(arr)) orders.push(...arr);
+        }
+        const guestKeys = await redis.keys('order:*');
+        for (const key of guestKeys) {
+            const o = await redis.get<Order>(key);
+            if (o) orders.push(o);
+        }
+    } catch (err) {
+        console.error('[finance] loadAllOrders failed:', err instanceof Error ? err.message : err);
+    }
+    return orders.filter((o) => !o.isTest);
+}
+
+export async function loadAllProducts(): Promise<Product[]> {
+    const products: Product[] = [];
+    try {
+        const keys = await redis.keys('product:*');
+        for (const key of keys) {
+            const p = await redis.get<Product>(key);
+            if (p) products.push(p);
+        }
+    } catch (err) {
+        console.error('[finance] loadAllProducts failed:', err instanceof Error ? err.message : err);
+    }
+    return products;
+}
+
+/** variantId → variant, for cost fallback + naming. */
+function indexVariants(products: Product[]): Map<string, { variant: ProductVariant; product: Product }> {
+    const map = new Map<string, { variant: ProductVariant; product: Product }>();
+    for (const p of products) {
+        for (const v of p.variants || []) {
+            map.set(String(v.variant_id || v.id), { variant: v, product: p });
+        }
+    }
+    return map;
+}
+
+function periodStart(period: Period, now: Date): Date | null {
+    if (period === 'all') return null;
+    const d = new Date(now);
+    if (period === 'week') d.setDate(now.getDate() - 7);
+    else if (period === 'month') d.setMonth(now.getMonth() - 1);
+    else if (period === 'year') d.setFullYear(now.getFullYear() - 1);
+    return d;
+}
+
+// ── Inventory valuation ────────────────────────────────────────────────────────
+
+export interface ValuationRow {
+    productId: string;
+    variantId: string;
+    productName: string;
+    variantName: string;
+    category?: string;
+    onHand: number | null;     // null = untracked/unlimited (excluded from value)
+    unitCost: number | null;   // null = uncosted
+    value: number;             // onHand * unitCost, 0 when either is unknown
+    costed: boolean;           // false when unitCost is unknown (flags coverage gaps)
+}
+
+export interface Valuation {
+    rows: ValuationRow[];
+    totalValue: number;
+    totalUnits: number;            // counted on-hand units across tracked variants
+    trackedVariants: number;
+    costedVariants: number;        // tracked variants that also have a unit cost
+    uncostedVariants: number;      // tracked, on-hand > 0, but no cost set
+    untrackedVariants: number;     // unlimited variants (no stock number)
+    byCategory: Array<{ category: string; value: number; units: number }>;
+}
+
+/**
+ * Current inventory valuation: on-hand units × weighted-avg unit cost, per variant,
+ * with category rollups and coverage flags. On-hand = variant.stock (reserved units
+ * are still ours until a sale commits, so they count toward what we hold).
+ */
+export async function getInventoryValuation(): Promise<Valuation> {
+    const products = await loadAllProducts();
+    const variantIds = products.flatMap((p) => (p.variants || []).map((v) => String(v.variant_id || v.id)));
+    const stocks = await getVariantStocks(variantIds).catch(() => ({} as Record<string, { stock: number | null }>));
+
+    const rows: ValuationRow[] = [];
+    const catMap = new Map<string, { value: number; units: number }>();
+    let totalValue = 0;
+    let totalUnits = 0;
+    let trackedVariants = 0;
+    let costedVariants = 0;
+    let uncostedVariants = 0;
+    let untrackedVariants = 0;
+
+    for (const p of products) {
+        for (const v of p.variants || []) {
+            const variantId = String(v.variant_id || v.id);
+            // Prefer the live inventory base (kept in step with sales) over the
+            // product record's snapshot; fall back to the product field.
+            const liveStock = stocks[variantId]?.stock;
+            const onHand = typeof liveStock === 'number'
+                ? liveStock
+                : (typeof v.stock === 'number' ? v.stock : null);
+            const unitCost = typeof v.unitCost === 'number' ? v.unitCost : null;
+
+            if (onHand === null) {
+                untrackedVariants++;
+            } else {
+                trackedVariants++;
+                totalUnits += onHand;
+                if (unitCost !== null) costedVariants++;
+                else if (onHand > 0) uncostedVariants++;
+            }
+
+            const value = onHand !== null && unitCost !== null ? round2(onHand * unitCost) : 0;
+            totalValue += value;
+
+            const category = p.category || 'Uncategorized';
+            if (value > 0 || (onHand ?? 0) > 0) {
+                const c = catMap.get(category) || { value: 0, units: 0 };
+                c.value += value;
+                c.units += onHand ?? 0;
+                catMap.set(category, c);
+            }
+
+            rows.push({
+                productId: String(p.id),
+                variantId,
+                productName: p.name,
+                variantName: v.name,
+                category: p.category,
+                onHand,
+                unitCost,
+                value,
+                costed: unitCost !== null,
+            });
+        }
+    }
+
+    rows.sort((a, b) => b.value - a.value);
+    const byCategory = Array.from(catMap, ([category, v]) => ({ category, value: round2(v.value), units: v.units }))
+        .sort((a, b) => b.value - a.value);
+
+    return {
+        rows,
+        totalValue: round2(totalValue),
+        totalUnits,
+        trackedVariants,
+        costedVariants,
+        uncostedVariants,
+        untrackedVariants,
+        byCategory,
+    };
+}
+
+// ── COGS & margin ──────────────────────────────────────────────────────────────
+
+/** Resolve a sold line's per-unit cost: captured-at-sale first, else current variant cost. */
+function lineUnitCost(
+    item: Order['items'][number],
+    variants: Map<string, { variant: ProductVariant; product: Product }>,
+): { cost: number; estimated: boolean } {
+    if (typeof item.unitCost === 'number' && item.unitCost >= 0) {
+        return { cost: item.unitCost, estimated: false };
+    }
+    if (item.variantId) {
+        const v = variants.get(String(item.variantId));
+        if (v && typeof v.variant.unitCost === 'number') return { cost: v.variant.unitCost, estimated: true };
+    }
+    return { cost: 0, estimated: true };
+}
+
+export interface MarginProductRow {
+    name: string;
+    variantId?: string;
+    unitsSold: number;
+    revenue: number;     // cash (USD); points lines contribute 0
+    cogs: number;
+    margin: number;      // revenue - cogs
+    marginPct: number | null;
+}
+
+export interface CogsAndMargin {
+    period: Period;
+    // Cash pathway (guest/Stripe): the real P&L line.
+    cashRevenue: number;
+    cashCogs: number;
+    cashMargin: number;        // cashRevenue - cashCogs
+    cashMarginPct: number | null;
+    // Points pathway: $0 cash revenue, but real money was spent fulfilling them.
+    pointsCogs: number;
+    pointsSpent: number;       // points (not USD)
+    pointsOrders: number;
+    // Combined COGS (cash + points) — total cost of everything that left the door.
+    totalCogs: number;
+    unitsSold: number;
+    ordersCounted: number;
+    estimatedLineShare: number; // fraction of COGS lines that used the fallback cost
+    byProduct: MarginProductRow[];
+    topByMargin: MarginProductRow[];
+    bottomByMargin: MarginProductRow[];
+}
+
+export async function getCogsAndMargin(period: Period = 'all', now = new Date()): Promise<CogsAndMargin> {
+    const [orders, products] = await Promise.all([loadAllOrders(), loadAllProducts()]);
+    const variants = indexVariants(products);
+    const start = periodStart(period, now);
+
+    // Only orders that represent a real sale: paid (or fulfilled/approved) — never
+    // unpaid/abandoned guest sessions or denied/refunded orders.
+    const sold = orders.filter((o) => {
+        if (start && new Date(o.createdAt) < start) return false;
+        if (o.paymentStatus === 'refunded') return false;
+        if (o.status === 'denied' || o.status === 'refunded') return false;
+        if (o.pathway === 'guest') return o.paymentStatus === 'paid';
+        return true; // student/points orders settle in-request
+    });
+
+    let cashRevenue = 0;
+    let cashCogs = 0;
+    let pointsCogs = 0;
+    let pointsSpent = 0;
+    let pointsOrders = 0;
+    let unitsSold = 0;
+    let estimatedLines = 0;
+    let totalLines = 0;
+    const productAgg = new Map<string, MarginProductRow>();
+
+    for (const o of sold) {
+        const isCash = o.pathway === 'guest';
+        if (!isCash) pointsOrders++;
+        if (!isCash) pointsSpent += o.pointsSpent || 0;
+
+        for (const item of o.items || []) {
+            const qty = item.quantity || 0;
+            if (qty <= 0) continue;
+            totalLines++;
+            const { cost, estimated } = lineUnitCost(item, variants);
+            if (estimated) estimatedLines++;
+            const lineCogs = round2(cost * qty);
+            const lineRevenue = isCash ? round2(parseFloat(item.price || '0') * qty) : 0;
+
+            unitsSold += qty;
+            if (isCash) {
+                cashRevenue += lineRevenue;
+                cashCogs += lineCogs;
+            } else {
+                pointsCogs += lineCogs;
+            }
+
+            const key = item.variantId ? String(item.variantId) : item.name;
+            const row = productAgg.get(key) || {
+                name: item.name,
+                variantId: item.variantId ? String(item.variantId) : undefined,
+                unitsSold: 0, revenue: 0, cogs: 0, margin: 0, marginPct: null,
+            };
+            row.unitsSold += qty;
+            row.revenue += lineRevenue;
+            row.cogs += lineCogs;
+            productAgg.set(key, row);
+        }
+    }
+
+    const byProduct = Array.from(productAgg.values()).map((r) => {
+        const revenue = round2(r.revenue);
+        const cogs = round2(r.cogs);
+        const margin = round2(revenue - cogs);
+        return { ...r, revenue, cogs, margin, marginPct: revenue > 0 ? round2((margin / revenue) * 100) : null };
+    }).sort((a, b) => b.margin - a.margin);
+
+    cashRevenue = round2(cashRevenue);
+    cashCogs = round2(cashCogs);
+    pointsCogs = round2(pointsCogs);
+    const cashMargin = round2(cashRevenue - cashCogs);
+
+    return {
+        period,
+        cashRevenue,
+        cashCogs,
+        cashMargin,
+        cashMarginPct: cashRevenue > 0 ? round2((cashMargin / cashRevenue) * 100) : null,
+        pointsCogs,
+        pointsSpent,
+        pointsOrders,
+        totalCogs: round2(cashCogs + pointsCogs),
+        unitsSold,
+        ordersCounted: sold.length,
+        estimatedLineShare: totalLines > 0 ? round2(estimatedLines / totalLines) : 0,
+        byProduct,
+        topByMargin: byProduct.slice(0, 10),
+        bottomByMargin: byProduct.filter((r) => r.revenue > 0).slice(-10).reverse(),
+    };
+}
+
+// ── Receiving spend ──────────────────────────────────────────────────────────
+
+export interface Spend {
+    period: Period;
+    totalSpend: number;
+    receiptCount: number;
+    unitsReceived: number;
+}
+
+export async function getSpend(period: Period = 'all', now = new Date()): Promise<Spend> {
+    const receipts = await readReceipts(2000);
+    const start = periodStart(period, now);
+    const inPeriod = receipts.filter((r) => !start || new Date(r.receivedAt) >= start);
+    return {
+        period,
+        totalSpend: round2(inPeriod.reduce((s, r) => s + (r.totalCost || 0), 0)),
+        receiptCount: inPeriod.length,
+        unitsReceived: inPeriod.reduce((s, r) => s + (r.quantity || 0), 0),
+    };
+}
+
+// ── Time series (for charts) ───────────────────────────────────────────────────
+
+/** ISO week key (YYYY-Www) and the week's Monday 00:00 (local). */
+export function isoWeek(d: Date): { key: string; start: Date } {
+    const date = new Date(Date.UTC(d.getFullYear(), d.getMonth(), d.getDate()));
+    const day = date.getUTCDay() || 7;            // Mon=1..Sun=7
+    date.setUTCDate(date.getUTCDate() + 4 - day); // nearest Thursday
+    const yearStart = new Date(Date.UTC(date.getUTCFullYear(), 0, 1));
+    const week = Math.ceil(((date.getTime() - yearStart.getTime()) / 86400000 + 1) / 7);
+    const start = new Date(Date.UTC(d.getFullYear(), d.getMonth(), d.getDate()));
+    const sDay = start.getUTCDay() || 7;
+    start.setUTCDate(start.getUTCDate() - (sDay - 1));
+    start.setUTCHours(0, 0, 0, 0);
+    return { key: `${date.getUTCFullYear()}-W${String(week).padStart(2, '0')}`, start };
+}
+
+export interface WeekPoint {
+    week: string;           // ISO week key
+    weekStart: string;      // ISO date (Monday)
+    cashRevenue: number;
+    cashCogs: number;
+    cashMargin: number;
+    pointsCogs: number;
+    spend: number;
+    unitsSold: number;
+    unitsReceived: number;
+    orders: number;
+}
+
+/** Weekly series over the trailing `weeks` ISO weeks (oldest → newest). */
+export async function getWeeklySeries(weeks = 12, now = new Date()): Promise<WeekPoint[]> {
+    const [orders, products, receipts] = await Promise.all([loadAllOrders(), loadAllProducts(), readReceipts(2000)]);
+    const variants = indexVariants(products);
+
+    const buckets = new Map<string, WeekPoint>();
+    const ensure = (d: Date) => {
+        const { key, start } = isoWeek(d);
+        let b = buckets.get(key);
+        if (!b) {
+            b = { week: key, weekStart: start.toISOString().slice(0, 10), cashRevenue: 0, cashCogs: 0, cashMargin: 0, pointsCogs: 0, spend: 0, unitsSold: 0, unitsReceived: 0, orders: 0 };
+            buckets.set(key, b);
+        }
+        return b;
+    };
+
+    for (const o of orders) {
+        const isCash = o.pathway === 'guest';
+        if (isCash && o.paymentStatus !== 'paid') continue;
+        if (o.paymentStatus === 'refunded' || o.status === 'denied' || o.status === 'refunded') continue;
+        const b = ensure(new Date(o.createdAt));
+        b.orders++;
+        for (const item of o.items || []) {
+            const qty = item.quantity || 0;
+            if (qty <= 0) continue;
+            const { cost } = lineUnitCost(item, variants);
+            b.unitsSold += qty;
+            if (isCash) {
+                b.cashRevenue = round2(b.cashRevenue + parseFloat(item.price || '0') * qty);
+                b.cashCogs = round2(b.cashCogs + cost * qty);
+            } else {
+                b.pointsCogs = round2(b.pointsCogs + cost * qty);
+            }
+        }
+        b.cashMargin = round2(b.cashRevenue - b.cashCogs);
+    }
+
+    for (const r of receipts) {
+        const b = ensure(new Date(r.receivedAt));
+        b.spend = round2(b.spend + (r.totalCost || 0));
+        b.unitsReceived += r.quantity || 0;
+    }
+
+    // Trailing N weeks ending this week, filling empty weeks with zeros so charts
+    // don't have gaps.
+    const series: WeekPoint[] = [];
+    for (let i = weeks - 1; i >= 0; i--) {
+        const d = new Date(now);
+        d.setDate(now.getDate() - i * 7);
+        const { key, start } = isoWeek(d);
+        series.push(buckets.get(key) || {
+            week: key, weekStart: start.toISOString().slice(0, 10),
+            cashRevenue: 0, cashCogs: 0, cashMargin: 0, pointsCogs: 0, spend: 0, unitsSold: 0, unitsReceived: 0, orders: 0,
+        });
+    }
+    return series;
+}
+
+// ── Weekly report (the finance headline) ────────────────────────────────────────
+
+export interface DeadStockRow {
+    variantId: string;
+    productName: string;
+    variantName: string;
+    onHand: number;
+    value: number;
+    lastSold: string | null;   // ISO date or null if never sold
+}
+
+export interface WeeklyReport {
+    week: string;
+    weekStart: string;
+    weekEnd: string;
+    // Sales
+    unitsSold: number;
+    cashRevenue: number;
+    cashCogs: number;
+    cashMargin: number;
+    cashMarginPct: number | null;
+    pointsCogs: number;
+    pointsSpent: number;
+    orders: number;
+    // Purchasing
+    unitsReceived: number;
+    spend: number;
+    receiptCount: number;
+    // Position at report time
+    endingInventoryValue: number;
+    lowStock: Array<{ variantId: string; productName: string; variantName: string; available: number | null }>;
+    deadStock: DeadStockRow[];   // on-hand value but no sale in the dead-stock window
+    uncostedVariants: number;
+}
+
+const LOW_STOCK_THRESHOLD = 5;
+const DEAD_STOCK_WEEKS = 8;
+
+/**
+ * One ISO-week rollup — the artifact the finance team reads. `weekContaining` is
+ * any date inside the desired week (defaults to now). Combines that week's sales,
+ * COGS/margin, and purchasing with the current inventory position, low-stock, and
+ * dead-stock flags.
+ */
+export async function getWeeklyReport(weekContaining = new Date()): Promise<WeeklyReport> {
+    const { key, start } = isoWeek(weekContaining);
+    const end = new Date(start);
+    end.setUTCDate(end.getUTCDate() + 7); // exclusive upper bound
+
+    const [orders, products, receipts, valuation] = await Promise.all([
+        loadAllOrders(), loadAllProducts(), readReceipts(2000), getInventoryValuation(),
+    ]);
+    const variants = indexVariants(products);
+
+    const inWeek = (iso: string | Date) => {
+        const t = new Date(iso).getTime();
+        return t >= start.getTime() && t < end.getTime();
+    };
+
+    let unitsSold = 0, cashRevenue = 0, cashCogs = 0, pointsCogs = 0, pointsSpent = 0, orderCount = 0;
+    const lastSoldByVariant = new Map<string, number>();
+
+    for (const o of orders) {
+        const isCash = o.pathway === 'guest';
+        if (isCash && o.paymentStatus !== 'paid') continue;
+        if (o.paymentStatus === 'refunded' || o.status === 'denied' || o.status === 'refunded') continue;
+        const ts = new Date(o.createdAt).getTime();
+        for (const item of o.items || []) {
+            if (item.variantId) {
+                const prev = lastSoldByVariant.get(String(item.variantId)) || 0;
+                if (ts > prev) lastSoldByVariant.set(String(item.variantId), ts);
+            }
+        }
+        if (!inWeek(o.createdAt)) continue;
+        orderCount++;
+        if (!isCash) pointsSpent += o.pointsSpent || 0;
+        for (const item of o.items || []) {
+            const qty = item.quantity || 0;
+            if (qty <= 0) continue;
+            const { cost } = lineUnitCost(item, variants);
+            unitsSold += qty;
+            if (isCash) {
+                cashRevenue = round2(cashRevenue + parseFloat(item.price || '0') * qty);
+                cashCogs = round2(cashCogs + cost * qty);
+            } else {
+                pointsCogs = round2(pointsCogs + cost * qty);
+            }
+        }
+    }
+
+    const weekReceipts = receipts.filter((r) => inWeek(r.receivedAt));
+    const spend = round2(weekReceipts.reduce((s, r) => s + (r.totalCost || 0), 0));
+    const unitsReceived = weekReceipts.reduce((s, r) => s + (r.quantity || 0), 0);
+
+    // Low stock from the operational layer.
+    const variantIds = products.flatMap((p) => (p.variants || []).map((v) => String(v.variant_id || v.id)));
+    const stocks = await getVariantStocks(variantIds).catch(() => ({} as Record<string, { available: number | null }>));
+    const lowStock = valuation.rows
+        .map((r) => ({ ...r, available: stocks[r.variantId]?.available ?? null }))
+        .filter((r) => r.available !== null && r.available <= LOW_STOCK_THRESHOLD)
+        .sort((a, b) => (a.available ?? 0) - (b.available ?? 0))
+        .slice(0, 50)
+        .map((r) => ({ variantId: r.variantId, productName: r.productName, variantName: r.variantName, available: r.available }));
+
+    // Dead stock: holds value but hasn't sold in the dead-stock window.
+    const deadCutoff = Date.now() - DEAD_STOCK_WEEKS * 7 * 86400000;
+    const deadStock: DeadStockRow[] = valuation.rows
+        .filter((r) => r.value > 0)
+        .filter((r) => {
+            const last = lastSoldByVariant.get(r.variantId);
+            return !last || last < deadCutoff;
+        })
+        .sort((a, b) => b.value - a.value)
+        .slice(0, 50)
+        .map((r) => ({
+            variantId: r.variantId,
+            productName: r.productName,
+            variantName: r.variantName,
+            onHand: r.onHand ?? 0,
+            value: r.value,
+            lastSold: lastSoldByVariant.has(r.variantId)
+                ? new Date(lastSoldByVariant.get(r.variantId)!).toISOString().slice(0, 10)
+                : null,
+        }));
+
+    const cashMargin = round2(cashRevenue - cashCogs);
+
+    return {
+        week: key,
+        weekStart: start.toISOString().slice(0, 10),
+        weekEnd: new Date(end.getTime() - 86400000).toISOString().slice(0, 10),
+        unitsSold,
+        cashRevenue,
+        cashCogs,
+        cashMargin,
+        cashMarginPct: cashRevenue > 0 ? round2((cashMargin / cashRevenue) * 100) : null,
+        pointsCogs,
+        pointsSpent,
+        orders: orderCount,
+        unitsReceived,
+        spend,
+        receiptCount: weekReceipts.length,
+        endingInventoryValue: valuation.totalValue,
+        lowStock,
+        deadStock,
+        uncostedVariants: valuation.uncostedVariants,
+    };
+}
+
+// ── Dashboard overview (one call powers the KPIs + charts) ──────────────────────
+
+export interface FinanceOverview {
+    period: Period;
+    valuation: Valuation;
+    margin: CogsAndMargin;
+    spend: Spend;
+    weeklySeries: WeekPoint[];
+    generatedAt: string;
+}
+
+export async function getFinanceOverview(period: Period = 'month', now = new Date()): Promise<FinanceOverview> {
+    const [valuation, margin, spend, weeklySeries] = await Promise.all([
+        getInventoryValuation(),
+        getCogsAndMargin(period, now),
+        getSpend(period, now),
+        getWeeklySeries(12, now),
+    ]);
+    return { period, valuation, margin, spend, weeklySeries, generatedAt: now.toISOString() };
+}
+
+export type { Receipt };

--- a/src/lib/productValidation.ts
+++ b/src/lib/productValidation.ts
@@ -18,6 +18,7 @@ interface ProductVariant {
     color?: string;
     image_url?: string;
     stock?: number;
+    unitCost?: number; // finance: cost basis per unit (USD), captured onto sold lines
 }
 
 interface CartItemForValidation {
@@ -70,6 +71,7 @@ export interface VerifiedCartItem {
     quantity: number;
     thumbnail_url?: string;
     variantId: string;      // canonical variant id, for stock reservation
+    unitCost?: number;      // finance: cost basis per unit (USD) at time of sale
 }
 
 /**
@@ -143,6 +145,7 @@ export async function validateCartItems(items: CartItemForValidation[]): Promise
             quantity: item.quantity,
             thumbnail_url: variant.image_url || product.image_url || product.thumbnail_url,
             variantId: String(variant.variant_id || variant.id),
+            unitCost: typeof variant.unitCost === 'number' && variant.unitCost >= 0 ? variant.unitCost : undefined,
         });
     }
 

--- a/src/types/Admin.ts
+++ b/src/types/Admin.ts
@@ -14,6 +14,10 @@ export interface AdminPermissions {
     canManageProducts: boolean;
     canViewStats: boolean;
     canManageAdmins: boolean;
+    // Finance: view cost/margin/valuation data and record stock receipts. Kept
+    // separate from canViewStats (order stats) and canManageProducts so cost
+    // basis and margin are only visible to finance-trusted roles.
+    canManageFinance: boolean;
 }
 
 export const ROLE_PERMISSIONS: Record<AdminRole, AdminPermissions> = {
@@ -24,6 +28,7 @@ export const ROLE_PERMISSIONS: Record<AdminRole, AdminPermissions> = {
         canManageProducts: true,
         canViewStats: true,
         canManageAdmins: true,
+        canManageFinance: true,
     },
     store_manager: {
         canManageUsers: false,
@@ -32,6 +37,7 @@ export const ROLE_PERMISSIONS: Record<AdminRole, AdminPermissions> = {
         canManageProducts: true,
         canViewStats: true,
         canManageAdmins: false,
+        canManageFinance: false,
     },
     reader: {
         canManageUsers: false,
@@ -40,6 +46,7 @@ export const ROLE_PERMISSIONS: Record<AdminRole, AdminPermissions> = {
         canManageProducts: false,
         canViewStats: true,
         canManageAdmins: false,
+        canManageFinance: false,
     },
 };
 
@@ -56,6 +63,10 @@ export interface ProductVariant {
     image_url?: string;
     stock?: number;
     weightOz?: number; // shipping weight per unit (oz), for live EasyPost rates
+    // Finance: current standard cost per unit (USD) — what we pay for one. Set by
+    // hand or recomputed as a weighted average when stock is received (see
+    // src/lib/costing.ts). Drives inventory valuation and COGS. Missing = uncosted.
+    unitCost?: number;
 }
 
 export interface ShippingOption {

--- a/src/types/Order.ts
+++ b/src/types/Order.ts
@@ -4,6 +4,13 @@ export interface OrderItem {
     price: string;
     quantity: number;
     thumbnail_url?: string;
+    // Finance: the variant sold and its cost basis (USD per unit) captured at the
+    // moment of sale, so cost-of-goods stays point-in-time even if the variant's
+    // standard cost changes later. Both optional — orders predating the finance
+    // layer (or lines that can't be mapped to a variant) simply omit them, and
+    // reporting falls back to the variant's current cost, flagged as estimated.
+    variantId?: string;
+    unitCost?: number;
 }
 
 /**


### PR DESCRIPTION
## What this adds

A **finance-grade costing & valuation layer** on top of the existing operational stock system. The shipped inventory track tracks *units* (stock, reserved, oversell prevention); this adds the financial dimension the finance team needs: **cost basis, valuation, COGS, margins, purchasing spend, weekly reports, and graphs.**

Spec: `FINANCE_INVENTORY_PROMPT.md` · Model & provenance: `docs/FINANCE.md`

## Highlights

- **`canManageFinance` permission** (managers only) — gates the page and all 5 APIs. Keeps cost/margin data separate from order stats and product editing.
- **`variant.unitCost`** (weighted-average) on the product type + admin form, preserved across product edits.
- **Receiving ledger** (`src/lib/costing.ts`) — record a purchase (qty + unit cost) → blends weighted-avg cost, bumps stock, audits (`inventory.receive`), mirrors to Airtable. Idempotent via `SET NX`.
- **Point-in-time COGS** — each sale captures the variant's cost onto the order line (`variantId` + `unitCost`) in `validateCartItems`, carried by both checkout pathways. The Stripe webhook only flips status, so cost persists.
- **Finance aggregation** (`src/lib/finance.ts`) — valuation, **cash-vs-points margin split**, spend, weekly rollup, 12-week series. Read-only, fail-soft, test-order-excluded.
- **`/admin/finance` dashboard** — KPI cards, 4 inline-SVG charts, valuation table, margin breakdown, weekly report (low/dead-stock flags + **formula-injection-safe CSV export**), and a receiving form.

## Invariants held

- Fire-and-forget safe — a finance read/write never blocks a sale.
- **No checkout/webhook behavior change** — COGS capture is purely additive; missing cost → 0, never a throw.
- Cash-vs-points keyed off `pathway`/`paymentStatus`, **not** `paymentMethod` — so it's already compatible with the in-progress HCB payment migration.
- No new dependencies; inline-SVG charts only.

## Verification

- `tsc --noEmit`, `next lint`, and `next build` all clean.
- `blendCost` weighted-average unit-tested 7/7, including the "prior units but no known cost" edge case.

## Known approximations (documented in `docs/FINANCE.md`)

1. Legacy orders (pre-finance-layer) use current variant cost as an estimate — surfaced as `estimatedLineShare` in the UI.
2. Weighted-average, not FIFO (per decision) — valuation doesn't track specific lots.
3. Refund-restock re-enters valuation at current avg, not original cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)