### PR TITLE
HCB OAuth auth-code fix + admin full-catalog buy + checkout polish

### DIFF
--- a/src/app/admin/finance/HcbConnectionCard.tsx
+++ b/src/app/admin/finance/HcbConnectionCard.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+
+/**
+ * Admin card for the HCB Donations connection. Guest checkout is paid by a
+ * donation on HCB; the shop reconciles those donations by reading the HCB v4
+ * transactions API. That read requires a token from a one-time OAuth connect
+ * (the HCB app can't do machine-to-machine auth), so an admin authorizes the
+ * app once here. Until connected, guest HCB orders can't auto-reconcile.
+ */
+type Status = { loading: boolean; configured: boolean; connected: boolean };
+
+export default function HcbConnectionCard() {
+    const [status, setStatus] = useState<Status>({ loading: true, configured: false, connected: false });
+    const [busy, setBusy] = useState(false);
+
+    const load = useCallback(async () => {
+        try {
+            const res = await fetch('/api/admin/hcb/status');
+            if (!res.ok) {
+                setStatus({ loading: false, configured: false, connected: false });
+                return;
+            }
+            const data = await res.json();
+            setStatus({ loading: false, configured: Boolean(data.configured), connected: Boolean(data.connected) });
+        } catch {
+            setStatus({ loading: false, configured: false, connected: false });
+        }
+    }, []);
+
+    useEffect(() => {
+        load();
+    }, [load]);
+
+    const disconnect = async () => {
+        if (busy) return;
+        setBusy(true);
+        try {
+            await fetch('/api/admin/hcb/status', { method: 'DELETE' });
+            await load();
+        } finally {
+            setBusy(false);
+        }
+    };
+
+    if (status.loading) return null;
+
+    const dot = status.connected ? 'bg-green-500' : status.configured ? 'bg-hackclub-orange' : 'bg-hackclub-muted';
+    const label = status.connected ? 'Connected' : status.configured ? 'Not connected' : 'Not configured';
+
+    return (
+        <div className="mb-6 p-5 rounded-2xl bg-white border-2 border-hackclub-smoke flex flex-wrap items-center justify-between gap-4">
+            <div className="flex items-start gap-3">
+                <span className={`mt-1.5 inline-block w-2.5 h-2.5 rounded-full ${dot}`} aria-hidden="true" />
+                <div>
+                    <p className="font-black text-hackclub-dark">HCB Donations — {label}</p>
+                    <p className="text-sm text-hackclub-slate max-w-xl">
+                        {!status.configured
+                            ? 'Set the HCB_* environment variables to enable guest donation checkout.'
+                            : status.connected
+                                ? 'Guest donations reconcile automatically. Reconnect if reads start failing.'
+                                : 'Authorize the shop with HCB once so guest donations can be matched to orders. Guest orders stay unpaid until this is connected.'}
+                    </p>
+                </div>
+            </div>
+            {status.configured && (
+                <div className="flex gap-2">
+                    {/* A full-page nav (not fetch) — the connect route 302s to HCB's login/consent. */}
+                    <a
+                        href="/api/admin/hcb/connect"
+                        className="inline-block bg-hackclub-red hover:bg-hackclub-orange text-white font-bold px-6 py-2.5 rounded-full transition-colors"
+                    >
+                        {status.connected ? 'Reconnect' : 'Connect HCB'}
+                    </a>
+                    {status.connected && (
+                        <button
+                            type="button"
+                            onClick={disconnect}
+                            disabled={busy}
+                            className="inline-block border-2 border-hackclub-smoke hover:border-hackclub-slate text-hackclub-slate font-bold px-6 py-2.5 rounded-full transition-colors disabled:opacity-50"
+                        >
+                            Disconnect
+                        </button>
+                    )}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/app/admin/finance/page.tsx
+++ b/src/app/admin/finance/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useMemo, useCallback } from 'react';
 import { useSession, signIn } from 'next-auth/react';
 import Link from 'next/link';
 import { motion } from 'framer-motion';
+import HcbConnectionCard from './HcbConnectionCard';
 
 // ── Types mirrored from src/lib/finance.ts (kept loose; this is a display layer) ──
 type Period = 'week' | 'month' | 'year' | 'all';
@@ -107,6 +108,8 @@ export default function FinanceAdmin() {
                     <p className="text-lg text-hackclub-slate font-medium mb-6">
                         On-hand value, cost of goods, margins, purchasing spend, and the weekly report. Cost basis is weighted-average per variant — see <Link href="/admin/inventory" className="text-hackclub-blue hover:underline font-bold">Inventory</Link> for units.
                     </p>
+
+                    <HcbConnectionCard />
 
                     {error && (
                         <div className="mb-4 p-4 bg-hackclub-red/10 border-2 border-hackclub-red rounded-xl">

--- a/src/app/api/admin/hcb/callback/route.ts
+++ b/src/app/api/admin/hcb/callback/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { Redis } from '@upstash/redis';
+import { authOptions } from '../../../auth/[...nextauth]/route';
+import { isAdmin } from '../../../../../lib/adminAuth';
+import { exchangeCodeForTokens } from '../../../../../lib/hcb';
+
+const redis = new Redis({
+    url: process.env.UPSTASH_REDIS_REST_URL!,
+    token: process.env.UPSTASH_REDIS_REST_TOKEN!,
+});
+
+/**
+ * Complete the HCB OAuth connect: validate the CSRF `state` minted by
+ * /api/admin/hcb/connect, then exchange the authorization `code` for tokens
+ * (the refresh token is persisted server-side by lib/hcb). Admin-only.
+ */
+export async function POST(request: Request) {
+    const session = await getServerSession(authOptions);
+    if (!(await isAdmin(session))) {
+        return NextResponse.json({ error: 'Unauthorized' }, { status: 403 });
+    }
+
+    const { code, state } = (await request.json().catch(() => ({}))) as { code?: string; state?: string };
+    if (!code || !state) {
+        return NextResponse.json({ error: 'Missing code or state.' }, { status: 400 });
+    }
+
+    // Validate + consume the one-time state. It must belong to this admin.
+    let stateUser: string | null;
+    try {
+        stateUser = await redis.get<string>(`hcb:oauth:state:${state}`);
+    } catch {
+        return NextResponse.json({ error: 'Could not verify the request. Try connecting again.' }, { status: 500 });
+    }
+    if (!stateUser || stateUser !== session!.user!.id) {
+        return NextResponse.json({ error: 'Invalid or expired connection request. Try again.' }, { status: 400 });
+    }
+    void redis.del(`hcb:oauth:state:${state}`);
+
+    const ok = await exchangeCodeForTokens(code);
+    if (!ok) {
+        return NextResponse.json({ error: 'Failed to connect HCB. Check the app credentials and try again.' }, { status: 502 });
+    }
+    return NextResponse.json({ connected: true });
+}

--- a/src/app/api/admin/hcb/connect/route.ts
+++ b/src/app/api/admin/hcb/connect/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { randomBytes } from 'crypto';
+import { Redis } from '@upstash/redis';
+import { authOptions } from '../../../auth/[...nextauth]/route';
+import { isAdmin } from '../../../../../lib/adminAuth';
+import { isHcbConfigured, buildAuthorizeUrl } from '../../../../../lib/hcb';
+
+const redis = new Redis({
+    url: process.env.UPSTASH_REDIS_REST_URL!,
+    token: process.env.UPSTASH_REDIS_REST_TOKEN!,
+});
+
+/**
+ * Start the one-time HCB OAuth connect. Admin-only. Generates a CSRF `state`,
+ * stashes it in Redis (short TTL), and redirects the admin to HCB's authorize
+ * page. HCB returns them to /hcb/callback?code=…&state=…, which posts the code
+ * to /api/admin/hcb/callback to complete the exchange.
+ *
+ * Required because the HCB app can't do machine-to-machine auth — a human admin
+ * who can see the org must authorize the app to read its transactions.
+ */
+export async function GET() {
+    const session = await getServerSession(authOptions);
+    if (!(await isAdmin(session))) {
+        return NextResponse.json({ error: 'Unauthorized' }, { status: 403 });
+    }
+    if (!isHcbConfigured()) {
+        return NextResponse.json({ error: 'HCB is not configured.' }, { status: 503 });
+    }
+
+    const state = randomBytes(24).toString('hex');
+    try {
+        // 10-minute window to complete the round-trip.
+        await redis.set(`hcb:oauth:state:${state}`, session!.user!.id, { ex: 600 });
+    } catch {
+        return NextResponse.json({ error: 'Could not start the connection. Try again.' }, { status: 500 });
+    }
+
+    return NextResponse.redirect(buildAuthorizeUrl(state));
+}

--- a/src/app/api/admin/hcb/status/route.ts
+++ b/src/app/api/admin/hcb/status/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '../../../auth/[...nextauth]/route';
+import { isAdmin } from '../../../../../lib/adminAuth';
+import { isHcbConfigured, isHcbConnected, clearHcbConnection } from '../../../../../lib/hcb';
+
+/** Admin-only: is HCB configured + connected (a refresh token is stored)? */
+export async function GET() {
+    const session = await getServerSession(authOptions);
+    if (!(await isAdmin(session))) {
+        return NextResponse.json({ error: 'Unauthorized' }, { status: 403 });
+    }
+    return NextResponse.json({
+        configured: isHcbConfigured(),
+        connected: await isHcbConnected(),
+    });
+}
+
+/** Admin-only: disconnect HCB (drops the stored refresh token). */
+export async function DELETE() {
+    const session = await getServerSession(authOptions);
+    if (!(await isAdmin(session))) {
+        return NextResponse.json({ error: 'Unauthorized' }, { status: 403 });
+    }
+    await clearHcbConnection();
+    return NextResponse.json({ connected: false });
+}

--- a/src/app/api/checkout/hcb/route.ts
+++ b/src/app/api/checkout/hcb/route.ts
@@ -125,7 +125,12 @@ export async function POST(request: Request) {
         // From here on, a failure must release the stock we just reserved so a
         // crashed checkout doesn't leak held units.
         try {
-            const donateUrl = buildDonationUrl({ amountUsd: totalAmount, email: email || undefined, orderId });
+            const donateUrl = buildDonationUrl({
+                amountUsd: totalAmount,
+                email: email || undefined,
+                name: shippingAddress?.name || undefined,
+                orderId,
+            });
 
             const now = new Date();
             const order: Order = {

--- a/src/app/api/checkout/hcb/route.ts
+++ b/src/app/api/checkout/hcb/route.ts
@@ -1,4 +1,7 @@
 import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '../../auth/[...nextauth]/route';
+import { isAdmin } from '../../../../lib/adminAuth';
 import { isHcbConfigured, buildDonationUrl } from '../../../../lib/hcb';
 import { validateCartItems, getProductById } from '../../../../lib/productValidation';
 import { isStructuredAddress, validateAddress } from '../../../../lib/address';
@@ -66,13 +69,28 @@ export async function POST(request: Request) {
             return NextResponse.json({ error: validation.error }, { status: 400 });
         }
 
-        // Every item the guest buys must have a cash price.
-        const nonCashItem = validation.items!.find(i => !i.priceCash || i.priceCash <= 0);
-        if (nonCashItem) {
-            return NextResponse.json({ error: `${nonCashItem.name} isn't available for purchase.` }, { status: 400 });
+        // Admins (full-catalog mode) may donate-pay for ANY item — a points-only
+        // item is charged at 1 point = $1. Regular guests may only buy cash-priced
+        // items.
+        const buyerIsAdmin = await isAdmin(await getServerSession(authOptions));
+
+        // Effective per-item cash cost: the real cash price, or (for admins) the
+        // points price at 1:1 when no cash price exists.
+        const itemCashCost = (i: { priceCash?: number; pricePoints?: number }): number => {
+            if (i.priceCash && i.priceCash > 0) return i.priceCash;
+            if (buyerIsAdmin && i.pricePoints && i.pricePoints > 0) return i.pricePoints;
+            return 0;
+        };
+
+        if (!buyerIsAdmin) {
+            // Every item a (non-admin) guest buys must have a cash price.
+            const nonCashItem = validation.items!.find(i => !i.priceCash || i.priceCash <= 0);
+            if (nonCashItem) {
+                return NextResponse.json({ error: `${nonCashItem.name} isn't available for purchase.` }, { status: 400 });
+            }
         }
 
-        const itemsCashTotal = validation.verifiedCashTotal!;
+        const itemsCashTotal = validation.items!.reduce((sum, i) => sum + itemCashCost(i) * i.quantity, 0);
 
         // Reserve stock before handing off to HCB, so two guests can't both buy
         // the last unit during the in-flight donation window. Untracked variants

--- a/src/app/api/orders/route.ts
+++ b/src/app/api/orders/route.ts
@@ -8,6 +8,7 @@ import { rateLimit, rateLimitResponse } from '../../../lib/rateLimit';
 import { PointsTransaction } from '../../../types/Points';
 import { validateCSRFToken } from '../../../lib/csrf';
 import { validateCartItems } from '../../../lib/productValidation';
+import { isAdmin } from '../../../lib/adminAuth';
 import { commitImmediate, restock, StockLine } from '../../../lib/inventory';
 import { mirrorOrder, mirrorUser } from '../../../lib/airtableMirror';
 import { sendEmail, buildOrderConfirmation, buildAdminNewOrder } from '../../../lib/email';
@@ -106,13 +107,31 @@ export async function POST(request: Request) {
             return NextResponse.json({ error: validation.error }, { status: 400 });
         }
 
-        const verifiedItemPointsTotal = validation.verifiedPointsTotal || 0;
+        // Admins (full-catalog mode) may pay points for ANY item — a cash-only
+        // item is charged at 1 point = $1. Regular students may only buy
+        // points-priced items.
+        const buyerIsAdmin = await isAdmin(session);
 
-        // Every item a student buys must be points-priced.
-        const nonPointsItem = validation.items!.find(i => !i.pricePoints || i.pricePoints <= 0);
-        if (nonPointsItem) {
-            return NextResponse.json({ error: `${nonPointsItem.name} can't be bought with points.` }, { status: 400 });
+        // Effective per-item points cost: the real points price, or (for admins)
+        // the cash price at 1:1 when no points price exists.
+        const itemPointsCost = (i: { pricePoints?: number; priceCash?: number }): number => {
+            if (i.pricePoints && i.pricePoints > 0) return i.pricePoints;
+            if (buyerIsAdmin && i.priceCash && i.priceCash > 0) return i.priceCash;
+            return 0;
+        };
+
+        if (!buyerIsAdmin) {
+            // Every item a (non-admin) student buys must be points-priced.
+            const nonPointsItem = validation.items!.find(i => !i.pricePoints || i.pricePoints <= 0);
+            if (nonPointsItem) {
+                return NextResponse.json({ error: `${nonPointsItem.name} can't be bought with points.` }, { status: 400 });
+            }
         }
+
+        const verifiedItemPointsTotal = validation.items!.reduce(
+            (sum, i) => sum + itemPointsCost(i) * i.quantity,
+            0,
+        );
 
         const verifiedPointsTotal = verifiedItemPointsTotal + shippingPointsNum;
 

--- a/src/app/checkout/page.tsx
+++ b/src/app/checkout/page.tsx
@@ -18,7 +18,13 @@ type CheckoutValue = string | ShippingAddress;
 
 const Checkout = () => {
     const { status } = useSession();
-    const { isStudent } = usePathway();
+    const { isStudent: isStudentPathway, isAdminMode } = usePathway();
+    // Admins (full-catalog mode) choose how to pay per order. Everyone else is
+    // fixed: students pay points, guests donate via HCB.
+    const [adminPayMode, setAdminPayMode] = useState<'points' | 'hcb'>('points');
+    // The single switch the rest of checkout keys off: true = points checkout,
+    // false = HCB donation checkout.
+    const payWithPoints = isAdminMode ? adminPayMode === 'points' : isStudentPathway;
     const cartContext = useContext(CartContext);
     const pointsContext = useContext(PointsContext);
     const [loading, setLoading] = useState(false);
@@ -100,14 +106,22 @@ const Checkout = () => {
 
     const { cart, clearCart } = cartContext;
 
-    // Student (points) totals.
-    const itemsPoints = cart.reduce((total, item) => total + (item.price_points || 0) * item.quantity, 0);
+    // Student (points) totals. For an admin paying points, a cash-only item
+    // (no points price) is charged at 1 point = $1 — must mirror the server.
+    const itemsPoints = cart.reduce((total, item) => {
+        const pts = item.price_points || (isAdminMode ? (item.price_cash || 0) : 0);
+        return total + pts * item.quantity;
+    }, 0);
     const shippingPointsCost = selectedShipping?.costPoints || 0;
     const requiredPoints = itemsPoints + shippingPointsCost;
 
     // Guest (cash) totals. Guests now choose a live shipping rate, so the shipping
-    // amount comes from selectedRate (falls back to 0 until one is chosen).
-    const itemsCash = cart.reduce((total, item) => total + (item.price_cash || 0) * item.quantity, 0);
+    // amount comes from selectedRate (falls back to 0 until one is chosen). For an
+    // admin paying HCB, a points-only item (no cash price) is charged at 1pt = $1.
+    const itemsCash = cart.reduce((total, item) => {
+        const cash = item.price_cash || (isAdminMode ? (item.price_points || 0) : 0);
+        return total + cash * item.quantity;
+    }, 0);
     const shippingCash = selectedRate?.cost ?? 0;
     const cashTotal = itemsCash + shippingCash;
 
@@ -115,7 +129,7 @@ const Checkout = () => {
     const hasEnoughPoints = pointsBalance >= requiredPoints;
     const remainingPointsNeeded = Math.max(0, requiredPoints - pointsBalance);
     const shippingSelected = shippingOptions.length === 0 || !!selectedShipping;
-    const canCheckout = isStudent
+    const canCheckout = payWithPoints
         ? hasEnoughPoints && cart.length > 0 && shippingSelected
         // Guests must have picked a shipping rate before paying.
         : itemsCash > 0 && cart.length > 0 && !!selectedRate;
@@ -253,7 +267,7 @@ const Checkout = () => {
         if (!validateCheckoutFields()) {
             return;
         }
-        if (isStudent) {
+        if (payWithPoints) {
             await handleStudentCheckout();
         } else {
             await handleGuestCheckout();
@@ -274,13 +288,36 @@ const Checkout = () => {
                         <div>
                             <h1 className="text-3xl font-black mb-2 text-hackclub-red">Checkout</h1>
                             <h2 className="text-lg font-bold text-hackclub-slate">
-                                {isStudent ? 'Pay with your points.' : 'Complete your order with a donation via HCB.'}
+                                {payWithPoints ? 'Pay with your points.' : 'Complete your order with a donation via HCB.'}
                             </h2>
                         </div>
 
+                        {/* Admin (full-catalog mode): choose how to pay this order. */}
+                        {isAdminMode && cart.length > 0 && (
+                            <div className="p-4 rounded-2xl bg-hackclub-smoke/30 border-2 border-hackclub-smoke">
+                                <label className="block font-bold text-hackclub-dark mb-3">Payment method (admin)</label>
+                                <div className="flex gap-2">
+                                    {(['points', 'hcb'] as const).map((m) => (
+                                        <button
+                                            key={m}
+                                            type="button"
+                                            onClick={() => setAdminPayMode(m)}
+                                            className={`flex-1 px-4 py-2 rounded-full font-bold text-sm transition-colors border-2 ${
+                                                adminPayMode === m
+                                                    ? 'bg-hackclub-red border-hackclub-red text-white'
+                                                    : 'bg-white border-hackclub-smoke text-hackclub-slate hover:border-hackclub-slate'
+                                            }`}
+                                        >
+                                            {m === 'points' ? 'Pay with points' : 'Donate via HCB'}
+                                        </button>
+                                    ))}
+                                </div>
+                            </div>
+                        )}
+
                         {/* Students pick a flat points-shipping country; guests get
                             live rates (below) and don't need this selector. */}
-                        {cart.length > 0 && isStudent && (
+                        {cart.length > 0 && payWithPoints && (
                             <motion.div initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }} className="p-4 rounded-2xl bg-hackclub-smoke/30 border-2 border-hackclub-smoke">
                                 <label className="block font-bold text-hackclub-dark mb-3">Shipping Country</label>
                                 {shippingOptions.length === 0 ? (
@@ -298,7 +335,7 @@ const Checkout = () => {
                                     >
                                         {shippingOptions.map((option, idx) => (
                                             <option key={option.id || `ship_${idx}`} value={option.id || `ship_${idx}`}>
-                                                {option.country} - {isStudent ? formatPoints(option.costPoints || 0) : formatCash(option.cost || 0)}
+                                                {option.country} - {payWithPoints ? formatPoints(option.costPoints || 0) : formatCash(option.cost || 0)}
                                             </option>
                                         ))}
                                     </select>
@@ -373,7 +410,7 @@ const Checkout = () => {
                             </motion.div>
                         )}
 
-                        {!isStudent && cart.length > 0 && (
+                        {!payWithPoints && cart.length > 0 && (
                             <motion.div initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }} className="p-4 rounded-2xl bg-hackclub-smoke/30 border-2 border-hackclub-smoke space-y-2">
                                 <label className="block font-bold text-hackclub-dark">Email for receipt</label>
                                 <input
@@ -390,7 +427,7 @@ const Checkout = () => {
 
                         {/* Live shipping rates (guests). Reads the address from
                             checkoutData; updates as the customer fills it in. */}
-                        {!isStudent && cart.length > 0 && (
+                        {!payWithPoints && cart.length > 0 && (
                             <LiveShippingRates
                                 items={cart.map((i) => ({ id: String(i.id), variant_id: i.variant_id ?? undefined, quantity: i.quantity || 1 }))}
                                 checkoutData={checkoutData}
@@ -413,7 +450,7 @@ const Checkout = () => {
                                                 <div className="text-hackclub-muted text-sm">Qty: {item.quantity || 1}</div>
                                             </div>
                                             <div className="font-black text-hackclub-red text-lg">
-                                                {isStudent
+                                                {payWithPoints
                                                     ? formatPoints((item.price_points || 0) * (item.quantity || 1))
                                                     : formatCash((item.price_cash || 0) * (item.quantity || 1))}
                                             </div>
@@ -426,25 +463,25 @@ const Checkout = () => {
                         <div className="bg-hackclub-smoke/30 rounded-2xl p-6 border-2 border-hackclub-smoke space-y-2">
                             <div className="flex justify-between items-center text-hackclub-slate">
                                 <span>Items:</span>
-                                <span>{isStudent ? formatPoints(itemsPoints) : formatCash(itemsCash)}</span>
+                                <span>{payWithPoints ? formatPoints(itemsPoints) : formatCash(itemsCash)}</span>
                             </div>
-                            {isStudent && shippingOptions.length > 0 && (
+                            {payWithPoints && shippingOptions.length > 0 && (
                                 <div className="flex justify-between items-center text-hackclub-slate">
                                     <span>Shipping ({selectedShipping?.country}):</span>
                                     <span>{formatPoints(shippingPointsCost)}</span>
                                 </div>
                             )}
-                            {!isStudent && selectedRate && (
+                            {!payWithPoints && selectedRate && (
                                 <div className="flex justify-between items-center text-hackclub-slate">
                                     <span>Shipping ({selectedRate.label}):</span>
                                     <span>{shippingCash > 0 ? formatCash(shippingCash) : 'Free'}</span>
                                 </div>
                             )}
                             <div className="flex justify-between items-center text-xl font-black pt-2 border-t border-hackclub-smoke">
-                                <span>{isStudent ? 'Points Required:' : 'Total:'}</span>
-                                <span className="text-hackclub-dark">{isStudent ? formatPoints(requiredPoints) : formatCash(cashTotal)}</span>
+                                <span>{payWithPoints ? 'Points Required:' : 'Total:'}</span>
+                                <span className="text-hackclub-dark">{payWithPoints ? formatPoints(requiredPoints) : formatCash(cashTotal)}</span>
                             </div>
-                            {isStudent && (
+                            {payWithPoints && (
                                 <div className="flex justify-between items-center text-sm text-hackclub-slate">
                                     <span>Your points:</span>
                                     <span>{formatPoints(pointsBalance)}</span>
@@ -481,15 +518,15 @@ const Checkout = () => {
                                 {loading ? (
                                     <motion.span key="processing" initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} className="inline-flex items-center justify-center gap-2">
                                         <span className="inline-block w-5 h-5 border-[3px] border-white/40 border-t-white rounded-full animate-spin" aria-hidden="true" />
-                                        {isStudent ? 'Processing…' : 'Opening donation page…'}
+                                        {payWithPoints ? 'Processing…' : 'Opening donation page…'}
                                     </motion.span>
                                 ) : canCheckout ? (
                                     <motion.span key="checkout" initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}>
-                                        {isStudent ? 'Checkout →' : 'Donate via HCB →'}
+                                        {payWithPoints ? 'Checkout →' : 'Donate via HCB →'}
                                     </motion.span>
                                 ) : (
                                     <motion.span key="insufficient" initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}>
-                                        {isStudent
+                                        {payWithPoints
                                             ? `Need ${remainingPointsNeeded} more points`
                                             : (cart.length === 0
                                                 ? 'Cart is empty'

--- a/src/app/hcb/callback/page.tsx
+++ b/src/app/hcb/callback/page.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useEffect, useState, useContext, Suspense } from 'react';
+import { useEffect, useState, useContext, useCallback, useRef, Suspense } from 'react';
 import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
 import { CartContext } from '../../../context/CartContext';
@@ -13,46 +13,56 @@ const CallbackInner = () => {
     // popup was blocked. Optional — the order also stores it server-side.
     const donateUrl = searchParams.get('donate');
     const [status, setStatus] = useState<Status>(orderId ? 'waiting' : 'notfound');
+    const [checking, setChecking] = useState(false);
     const cartContext = useContext(CartContext);
+    // Lets a manual "paid" result stop the background auto-poll loop.
+    const settledRef = useRef(false);
 
+    // One status check shared by the auto-poll loop and the manual button.
+    // Returns true once the order is confirmed paid (so the poller can stop).
+    const checkOnce = useCallback(async (): Promise<boolean> => {
+        if (!orderId) return false;
+        try {
+            const res = await fetch(`/api/checkout/hcb/status?orderId=${encodeURIComponent(orderId)}`);
+            if (res.status === 404) {
+                setStatus('notfound');
+                settledRef.current = true;
+                return false;
+            }
+            const data = await res.json();
+            if (data.paymentStatus === 'paid') {
+                cartContext?.clearCart();
+                setStatus('paid');
+                settledRef.current = true;
+                return true;
+            }
+        } catch {
+            // Network blip — caller will retry.
+        }
+        return false;
+    }, [orderId, cartContext]);
+
+    // Auto-poll: the donor pays on HCB in the other tab; the reconciler matches
+    // the donation back to this order. Poll until paid. Generous attempt budget
+    // (~3.5 min at 3s) since the donor has to fill the HCB form.
     useEffect(() => {
         if (!orderId) {
             setStatus('notfound');
             return;
         }
-
-        // The donor pays on HCB in the other tab; the reconciler matches the
-        // donation back to this order. Poll until it flips to paid. Generous
-        // attempt budget (~3.5 min at 3s) since the donor has to fill the HCB form.
         let cancelled = false;
         let attempts = 0;
         const MAX_ATTEMPTS = 70;
 
         const poll = async () => {
-            try {
-                const res = await fetch(`/api/checkout/hcb/status?orderId=${encodeURIComponent(orderId)}`);
-                if (cancelled) return;
-                if (res.status === 404) {
-                    setStatus('notfound');
-                    return;
-                }
-                const data = await res.json();
-                if (data.paymentStatus === 'paid') {
-                    cartContext?.clearCart();
-                    setStatus('paid');
-                    return;
-                }
-            } catch {
-                // Network blip — fall through and retry.
-            }
-
+            if (cancelled || settledRef.current) return;
+            const paid = await checkOnce();
+            if (cancelled || paid || settledRef.current) return;
             attempts += 1;
-            if (!cancelled) {
-                if (attempts < MAX_ATTEMPTS) {
-                    setTimeout(poll, 3000);
-                } else {
-                    setStatus('timeout');
-                }
+            if (attempts < MAX_ATTEMPTS) {
+                setTimeout(poll, 3000);
+            } else {
+                setStatus('timeout');
             }
         };
 
@@ -60,7 +70,18 @@ const CallbackInner = () => {
         return () => {
             cancelled = true;
         };
-    }, [orderId, cartContext]);
+    }, [orderId, checkOnce]);
+
+    // Manual "check now" — for an impatient donor who's already paid.
+    const handleManualCheck = useCallback(async () => {
+        if (checking) return;
+        setChecking(true);
+        const paid = await checkOnce();
+        // If they hit it after the auto-poll gave up, drop them back into the
+        // waiting state so the loop's "timeout" copy doesn't linger on a retry.
+        if (!paid) setStatus((s) => (s === 'timeout' ? 'waiting' : s));
+        setChecking(false);
+    }, [checking, checkOnce]);
 
     const heading =
         status === 'paid' ? 'Thank You!'
@@ -76,36 +97,45 @@ const CallbackInner = () => {
                     ? "We haven't seen your donation yet. If you've completed it, it can take a moment to appear — we'll email you as soon as it lands."
                     : 'Finish your donation on the HCB tab that just opened. This page will update automatically once it goes through.';
 
+    const showWaitingControls = status === 'waiting' || status === 'timeout';
+
     return (
         <div className="bg-white min-h-screen flex flex-col items-center justify-center text-hackclub-dark text-center px-4">
             <h1 className="text-5xl font-black text-hackclub-red mb-4">{heading}</h1>
             <p className="text-2xl font-bold mb-2 max-w-xl">{sub}</p>
 
             {status === 'waiting' && (
-                <>
-                    <p className="text-hackclub-muted mb-6 animate-pulse">Waiting for your donation…</p>
+                <p className="text-hackclub-muted mb-6 animate-pulse">Waiting for your donation…</p>
+            )}
+
+            {showWaitingControls && (
+                <div className="flex flex-wrap items-center justify-center gap-3 mb-8">
                     {donateUrl && (
                         <a
                             href={donateUrl}
                             target="_blank"
                             rel="noopener noreferrer"
-                            className="inline-block mb-8 bg-hackclub-red hover:bg-hackclub-orange text-white font-bold px-8 py-3 rounded-full shadow-lg transition-colors"
+                            className="inline-block bg-hackclub-red hover:bg-hackclub-orange text-white font-bold px-8 py-3 rounded-full shadow-lg transition-colors"
                         >
-                            Open the donation page →
+                            {status === 'timeout' ? 'Open the donation page again →' : 'Open the donation page →'}
                         </a>
                     )}
-                </>
+                    <button
+                        type="button"
+                        onClick={handleManualCheck}
+                        disabled={checking}
+                        className={`inline-flex items-center gap-2 border-2 font-bold px-8 py-3 rounded-full transition-colors ${
+                            checking
+                                ? 'border-hackclub-smoke text-hackclub-muted cursor-not-allowed'
+                                : 'border-hackclub-smoke hover:border-hackclub-slate text-hackclub-slate'
+                        }`}
+                    >
+                        {checking && <span className="inline-block w-4 h-4 border-2 border-hackclub-muted/40 border-t-hackclub-slate rounded-full animate-spin" aria-hidden="true" />}
+                        {checking ? 'Checking…' : "I've donated — check now"}
+                    </button>
+                </div>
             )}
-            {status === 'timeout' && donateUrl && (
-                <a
-                    href={donateUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="inline-block mb-8 bg-hackclub-red hover:bg-hackclub-orange text-white font-bold px-8 py-3 rounded-full shadow-lg transition-colors"
-                >
-                    Open the donation page again →
-                </a>
-            )}
+
             {status === 'paid' && (
                 <p className="text-hackclub-muted mb-8">A confirmation has been sent to your email.</p>
             )}

--- a/src/app/hcb/callback/page.tsx
+++ b/src/app/hcb/callback/page.tsx
@@ -9,6 +9,10 @@ type Status = 'waiting' | 'paid' | 'notfound' | 'timeout';
 const CallbackInner = () => {
     const searchParams = useSearchParams();
     const orderId = searchParams.get('orderId');
+    // OAuth return (admin connecting HCB): HCB redirects here with ?code=&state=.
+    const oauthCode = searchParams.get('code');
+    const oauthState = searchParams.get('state');
+    const isOAuthReturn = Boolean(oauthCode && oauthState);
     // Passed through from checkout so we can re-offer the donate link if the
     // popup was blocked. Optional — the order also stores it server-side.
     const donateUrl = searchParams.get('donate');
@@ -17,6 +21,28 @@ const CallbackInner = () => {
     const cartContext = useContext(CartContext);
     // Lets a manual "paid" result stop the background auto-poll loop.
     const settledRef = useRef(false);
+
+    // ── Admin OAuth return: exchange the code, then report connected/failed. ──
+    const [connectState, setConnectState] = useState<'exchanging' | 'connected' | 'failed'>('exchanging');
+    useEffect(() => {
+        if (!isOAuthReturn) return;
+        let cancelled = false;
+        (async () => {
+            try {
+                const res = await fetch('/api/admin/hcb/callback', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ code: oauthCode, state: oauthState }),
+                });
+                if (!cancelled) setConnectState(res.ok ? 'connected' : 'failed');
+            } catch {
+                if (!cancelled) setConnectState('failed');
+            }
+        })();
+        return () => {
+            cancelled = true;
+        };
+    }, [isOAuthReturn, oauthCode, oauthState]);
 
     // One status check shared by the auto-poll loop and the manual button.
     // Returns true once the order is confirmed paid (so the poller can stop).
@@ -46,6 +72,7 @@ const CallbackInner = () => {
     // the donation back to this order. Poll until paid. Generous attempt budget
     // (~3.5 min at 3s) since the donor has to fill the HCB form.
     useEffect(() => {
+        if (isOAuthReturn) return; // admin connect flow handled above
         if (!orderId) {
             setStatus('notfound');
             return;
@@ -70,7 +97,7 @@ const CallbackInner = () => {
         return () => {
             cancelled = true;
         };
-    }, [orderId, checkOnce]);
+    }, [orderId, checkOnce, isOAuthReturn]);
 
     // Manual "check now" — for an impatient donor who's already paid.
     const handleManualCheck = useCallback(async () => {
@@ -98,6 +125,29 @@ const CallbackInner = () => {
                     : 'Finish your donation on the HCB tab that just opened. This page will update automatically once it goes through.';
 
     const showWaitingControls = status === 'waiting' || status === 'timeout';
+
+    // ── Admin OAuth-return view (HCB connect). Distinct from the donor flow. ──
+    if (isOAuthReturn) {
+        const cHeading = connectState === 'connected' ? 'HCB Connected' : connectState === 'failed' ? "Couldn't connect HCB" : 'Connecting HCB…';
+        const cSub =
+            connectState === 'connected'
+                ? 'The shop can now reconcile donations automatically. You can close this page.'
+                : connectState === 'failed'
+                    ? 'The authorization didn’t complete. Head back to the admin dashboard and try connecting again.'
+                    : 'Finishing the connection with HCB…';
+        return (
+            <div className="bg-white min-h-screen flex flex-col items-center justify-center text-hackclub-dark text-center px-4">
+                <h1 className="text-5xl font-black text-hackclub-red mb-4">{cHeading}</h1>
+                <p className="text-2xl font-bold mb-6 max-w-xl">{cSub}</p>
+                {connectState === 'exchanging' && (
+                    <span className="inline-block w-6 h-6 border-[3px] border-hackclub-smoke border-t-hackclub-red rounded-full animate-spin mb-8" aria-hidden="true" />
+                )}
+                <div className="flex flex-wrap items-center justify-center gap-3">
+                    <Link href="/admin/finance" className="inline-block bg-hackclub-red hover:bg-hackclub-orange text-white font-bold px-8 py-3 rounded-full shadow-lg transition-colors">Back to admin</Link>
+                </div>
+            </div>
+        );
+    }
 
     return (
         <div className="bg-white min-h-screen flex flex-col items-center justify-center text-hackclub-dark text-center px-4">

--- a/src/app/products/[id]/page.tsx
+++ b/src/app/products/[id]/page.tsx
@@ -55,7 +55,7 @@ const ProductPage = () => {
             const cartItem = {
                 id: product.id,
                 name: selectedVariant.name,
-                price: String(getCashPrice(selectedVariant)),
+                price: String(getCashPrice(selectedVariant) || getPointsPrice(selectedVariant)),
                 price_cash: getCashPrice(selectedVariant) || undefined,
                 price_points: getPointsPrice(selectedVariant) || undefined,
                 thumbnail_url: selectedVariant.product.image,

--- a/src/app/shop/page.tsx
+++ b/src/app/shop/page.tsx
@@ -44,7 +44,7 @@ const Shop = () => {
     const [isReleasing, setIsReleasing] = useState(false);
     const [releaseOnCart, setReleaseOnCart] = useState(false);
     const cartContext = useContext(CartContext);
-    const { pathway, loading: pathwayLoading } = usePathway();
+    const { pathway, loading: pathwayLoading, isAdmin, isAdminMode, setAdminMode } = usePathway();
 
     // Catalog controls.
     const [query, setQuery] = useState('');
@@ -180,7 +180,7 @@ const Shop = () => {
                     cartContext.addToCart({
                         id: product.id,
                         name: variant.name,
-                        price: String(getCashPrice(variant)),
+                        price: String(getCashPrice(variant) || getPointsPrice(variant)),
                         price_cash: getCashPrice(variant) || undefined,
                         price_points: getPointsPrice(variant) || undefined,
                         thumbnail_url: variant.product.image,
@@ -266,6 +266,26 @@ const Shop = () => {
                             <CategoryChip key={c} label={c} active={category === c} onClick={() => setCategory(c)} />
                         ))}
                     </div>
+                )}
+
+                {/* Admin-only: reveal the full catalog (points + cash items) and pick
+                    how to pay per order at checkout. Off by default so an admin
+                    shopping as a normal student isn't surprised. */}
+                {isAdmin && (
+                    <label className="flex items-center gap-3 mb-8 px-4 py-3 rounded-2xl bg-hackclub-smoke/40 border-2 border-hackclub-smoke w-fit cursor-pointer select-none">
+                        <input
+                            type="checkbox"
+                            checked={isAdminMode}
+                            onChange={(e) => setAdminMode(e.target.checked)}
+                            className="w-4 h-4 accent-hackclub-red cursor-pointer"
+                        />
+                        <span className="font-bold text-hackclub-dark text-sm">
+                            Admin: show all products
+                        </span>
+                        <span className="text-hackclub-muted text-xs">
+                            {isAdminMode ? 'Viewing every product — pick points or HCB at checkout.' : 'Currently shopping as a student.'}
+                        </span>
+                    </label>
                 )}
 
                 {error && (
@@ -379,7 +399,7 @@ const Shop = () => {
                                                    cartContext.addToCart({
                                                        id: product.id,
                                                        name: variant.name,
-                                                       price: String(getCashPrice(variant)),
+                                                       price: String(getCashPrice(variant) || getPointsPrice(variant)),
                                                        price_cash: getCashPrice(variant) || undefined,
                                                        price_points: getPointsPrice(variant) || undefined,
                                                        thumbnail_url: variant.product.image,

--- a/src/lib/hcb.ts
+++ b/src/lib/hcb.ts
@@ -54,17 +54,20 @@ export function isHcbConfigured(): boolean {
 /**
  * Build the pre-filled HCB donation URL the donor is sent to. Amount is taken
  * verbatim from the server-derived order total (never a client-supplied price)
- * and rendered in DOLLARS, which is what the donation-start form expects. The
- * `utm_content` tag carries the order id back onto the donation record so
- * reconciliation can match it deterministically.
+ * and rendered in DOLLARS, which is what the donation-start form expects. Name
+ * and email pre-fill the donor's details on HCB (cosmetic — the shipping
+ * address lives on our order, not the donation). The `utm_content` tag carries
+ * the order id back onto the donation record so reconciliation can match it
+ * deterministically.
  */
-export function buildDonationUrl(opts: { amountUsd: number; email?: string; orderId: string }): string {
+export function buildDonationUrl(opts: { amountUsd: number; email?: string; name?: string; orderId: string }): string {
     const slug = process.env.HCB_ORG_SLUG || '';
     // Prefer an explicit donate base if provided (lets prod/staging differ from the API host).
     const base = (process.env.NEXT_PUBLIC_HCB_DONATE_BASE || `${DEFAULT_DONATE_HOST}/donations/start/${slug}`).replace(/\/+$/, '');
     const params = new URLSearchParams();
     params.set('amount', opts.amountUsd.toFixed(2));
     if (opts.email) params.set('email', opts.email);
+    if (opts.name) params.set('name', opts.name);
     params.set('utm_source', 'shop');
     params.set('utm_content', opts.orderId);
     return `${base}?${params.toString()}`;

--- a/src/lib/hcb.ts
+++ b/src/lib/hcb.ts
@@ -32,6 +32,13 @@
  *   NEXT_PUBLIC_HCB_DONATE_BASE   https://hcb.hackclub.com/donations/start/<slug>
  */
 
+import { Redis } from '@upstash/redis';
+
+const redis = new Redis({
+    url: process.env.UPSTASH_REDIS_REST_URL!,
+    token: process.env.UPSTASH_REDIS_REST_TOKEN!,
+});
+
 const DEFAULT_API_BASE = 'https://hcb.hackclub.com/api/v4';
 const DEFAULT_DONATE_HOST = 'https://hcb.hackclub.com';
 
@@ -73,47 +80,162 @@ export function buildDonationUrl(opts: { amountUsd: number; email?: string; name
     return `${base}?${params.toString()}`;
 }
 
-// ── OAuth token (the read path) ──────────────────────────────────────────────
+// ── OAuth token (the read path, authorization-code grant) ────────────────────
+//
+// The HCB app does NOT support client_credentials — confirmed against the live
+// API (it rejects the grant and redirects to a human login). So an admin
+// authorizes the app ONCE via the authorization-code flow; we persist the
+// refresh token in Redis and mint short-lived access tokens from it. The
+// reconciler reads transactions with the resulting bearer token.
 
-let _token: { value: string; expiresAt: number } | null = null;
+const REDIS_REFRESH_KEY = 'hcb:oauth:refresh_token';
+const REDIS_RET = 60 * 60 * 24 * 365; // keep the refresh token ~1y
 
-/**
- * Fetch (and cache) a bearer token via the client_credentials grant. Cached in
- * module memory until ~60s before expiry. Returns null when unconfigured or on
- * any failure — callers degrade to "couldn't reconcile yet" rather than throw.
- */
-async function getAccessToken(forceRefresh = false): Promise<string | null> {
-    if (!isHcbConfigured()) return null;
-    const now = Date.now();
-    if (!forceRefresh && _token && _token.expiresAt > now) return _token.value;
+// In-memory access-token cache (per server instance). The refresh token is the
+// durable secret; access tokens are cheap to re-mint.
+let _access: { value: string; expiresAt: number } | null = null;
 
+/** The redirect URI registered with the HCB app. Must match exactly. */
+function redirectUri(): string {
+    const origin = (process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000').replace(/\/+$/, '');
+    return `${origin}/hcb/callback`;
+}
+
+/** Build the HCB authorize URL an admin visits once to connect the shop. */
+export function buildAuthorizeUrl(state: string): string {
+    const params = new URLSearchParams({
+        client_id: process.env.HCB_CLIENT_ID || '',
+        redirect_uri: redirectUri(),
+        response_type: 'code',
+        scope: 'read',
+        state,
+    });
+    return `${apiBase()}/oauth/authorize?${params.toString()}`;
+}
+
+/** True once an admin has connected HCB (a refresh token is stored). */
+export async function isHcbConnected(): Promise<boolean> {
     try {
+        return Boolean(await redis.get<string>(REDIS_REFRESH_KEY));
+    } catch {
+        return false;
+    }
+}
+
+interface TokenResponse {
+    access_token?: string;
+    refresh_token?: string;
+    expires_in?: number;
+    error?: string;
+    error_description?: string;
+}
+
+async function postToken(body: Record<string, string>): Promise<TokenResponse | null> {
+    try {
+        const form = new URLSearchParams(body);
         const res = await fetch(`${apiBase()}/oauth/token`, {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-                grant_type: 'client_credentials',
-                client_id: process.env.HCB_CLIENT_ID,
-                client_secret: process.env.HCB_CLIENT_SECRET,
-                scope: 'read',
-            }),
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded', Accept: 'application/json' },
+            body: form.toString(),
+            redirect: 'manual',
         });
-        if (!res.ok) {
-            console.error('[hcb] token request failed:', res.status, (await res.text()).slice(0, 200));
+        const text = await res.text();
+        let data: TokenResponse;
+        try {
+            data = JSON.parse(text) as TokenResponse;
+        } catch {
+            console.error('[hcb] token endpoint returned non-JSON:', res.status, text.slice(0, 200));
             return null;
         }
-        const data = (await res.json()) as { access_token?: string; expires_in?: number };
-        if (!data.access_token) {
-            console.error('[hcb] token response missing access_token');
+        if (!res.ok || data.error) {
+            console.error('[hcb] token request failed:', res.status, data.error, data.error_description);
             return null;
         }
-        const ttlMs = (data.expires_in ?? 3600) * 1000;
-        _token = { value: data.access_token, expiresAt: now + ttlMs - 60_000 };
-        return _token.value;
+        return data;
     } catch (err) {
         console.error('[hcb] token request error:', err instanceof Error ? err.message : err);
         return null;
     }
+}
+
+/**
+ * Exchange an authorization code (from the /hcb/callback OAuth return) for an
+ * access + refresh token, and persist the refresh token. Returns true on
+ * success. Called once, by the admin connect flow.
+ */
+export async function exchangeCodeForTokens(code: string): Promise<boolean> {
+    if (!isHcbConfigured()) return false;
+    const data = await postToken({
+        grant_type: 'authorization_code',
+        code,
+        client_id: process.env.HCB_CLIENT_ID || '',
+        client_secret: process.env.HCB_CLIENT_SECRET || '',
+        redirect_uri: redirectUri(),
+    });
+    if (!data?.access_token || !data.refresh_token) {
+        console.error('[hcb] code exchange missing tokens');
+        return false;
+    }
+    try {
+        await redis.set(REDIS_REFRESH_KEY, data.refresh_token, { ex: REDIS_RET });
+    } catch (err) {
+        console.error('[hcb] failed to persist refresh token:', err instanceof Error ? err.message : err);
+        return false;
+    }
+    _access = { value: data.access_token, expiresAt: Date.now() + (data.expires_in ?? 7200) * 1000 - 60_000 };
+    return true;
+}
+
+/** Drop the stored connection (admin disconnect). */
+export async function clearHcbConnection(): Promise<void> {
+    _access = null;
+    try {
+        await redis.del(REDIS_REFRESH_KEY);
+    } catch {
+        // best-effort
+    }
+}
+
+/**
+ * Get a valid access token, minting a fresh one from the stored refresh token
+ * when the cached one is missing/expired (or forceRefresh is set). Returns null
+ * when HCB isn't connected or the refresh fails — callers degrade to "couldn't
+ * reconcile yet" rather than throw.
+ */
+async function getAccessToken(forceRefresh = false): Promise<string | null> {
+    if (!isHcbConfigured()) return null;
+    if (!forceRefresh && _access && _access.expiresAt > Date.now()) return _access.value;
+
+    let refreshToken: string | null;
+    try {
+        refreshToken = await redis.get<string>(REDIS_REFRESH_KEY);
+    } catch (err) {
+        console.error('[hcb] failed to read refresh token:', err instanceof Error ? err.message : err);
+        return null;
+    }
+    if (!refreshToken) {
+        // Not connected yet — an admin must authorize the app once.
+        return null;
+    }
+
+    const data = await postToken({
+        grant_type: 'refresh_token',
+        refresh_token: refreshToken,
+        client_id: process.env.HCB_CLIENT_ID || '',
+        client_secret: process.env.HCB_CLIENT_SECRET || '',
+    });
+    if (!data?.access_token) return null;
+
+    // Doorkeeper rotates refresh tokens — persist the new one if returned.
+    if (data.refresh_token && data.refresh_token !== refreshToken) {
+        try {
+            await redis.set(REDIS_REFRESH_KEY, data.refresh_token, { ex: REDIS_RET });
+        } catch {
+            // best-effort; the access token is still usable now
+        }
+    }
+    _access = { value: data.access_token, expiresAt: Date.now() + (data.expires_in ?? 7200) * 1000 - 60_000 };
+    return _access.value;
 }
 
 // ── Transactions (reconciliation) ────────────────────────────────────────────

--- a/src/lib/paymentUtils.ts
+++ b/src/lib/paymentUtils.ts
@@ -18,21 +18,33 @@ export function formatPoints(n: number): string {
     return `${Math.round(n)} pts`;
 }
 
-/** True if the variant can be bought on the given pathway. */
+/**
+ * True if the variant can be bought on the given pathway. Admins (full-catalog
+ * mode) can buy anything priced either way, so a variant is available to them
+ * if it has a points OR a cash price.
+ */
 export function isAvailableOn(variant: any, pathway: Pathway): boolean {
+    if (pathway === 'admin') return getPointsPrice(variant) > 0 || getCashPrice(variant) > 0;
     return pathway === 'student' ? getPointsPrice(variant) > 0 : getCashPrice(variant) > 0;
 }
 
 /**
  * The price to SHOW for a variant on a given pathway: dollars for guests,
- * points for students. Returns a display string, or null if the variant
- * isn't available on that pathway.
+ * points for students. Admins see both (whichever the variant has), joined
+ * with a separator. Returns a display string, or null if the variant isn't
+ * available on that pathway.
  */
 export function getDisplayPrice(variant: any, pathway: Pathway): string | null {
+    const p = getPointsPrice(variant);
+    const c = getCashPrice(variant);
+    if (pathway === 'admin') {
+        const parts: string[] = [];
+        if (p > 0) parts.push(formatPoints(p));
+        if (c > 0) parts.push(formatCash(c));
+        return parts.length > 0 ? parts.join(' · ') : null;
+    }
     if (pathway === 'student') {
-        const p = getPointsPrice(variant);
         return p > 0 ? formatPoints(p) : null;
     }
-    const c = getCashPrice(variant);
     return c > 0 ? formatCash(c) : null;
 }

--- a/src/lib/usePathway.ts
+++ b/src/lib/usePathway.ts
@@ -1,32 +1,101 @@
 'use client';
 
 import { useSession } from 'next-auth/react';
+import { useState, useEffect, useCallback } from 'react';
 
 /**
- * The two storefront pathways.
+ * The storefront pathways.
  * - 'student': signed in with Hack Club → pays with points.
  * - 'guest':   logged out → pays real money via an HCB donation.
+ * - 'admin':   a signed-in admin who has flipped on "show all products". Sees
+ *              the FULL catalog (both points- and cash-priced items) and picks
+ *              points or HCB per order at checkout. Opt-in: an admin who hasn't
+ *              toggled it behaves exactly like a normal 'student'.
  *
- * Pathway is derived purely from auth state; there is no manual toggle.
+ * Student/guest are derived purely from auth state. Admin mode is an explicit,
+ * per-browser toggle (persisted in localStorage) available only to admins.
  */
-export type Pathway = 'student' | 'guest';
+export type Pathway = 'student' | 'guest' | 'admin';
+
+const ADMIN_MODE_KEY = 'shop:adminMode';
 
 export interface PathwayState {
     pathway: Pathway;
     isStudent: boolean;
     isGuest: boolean;
-    /** Auth is still resolving; callers should avoid committing to a pathway yet. */
+    /** True when the active pathway is the admin "see everything" view. */
+    isAdminMode: boolean;
+    /** True when the signed-in user is an admin (regardless of the toggle). */
+    isAdmin: boolean;
+    /** Flip the admin "show all products" view on/off (no-op for non-admins). */
+    setAdminMode: (on: boolean) => void;
+    /** Auth/admin status is still resolving; callers should avoid committing to a pathway yet. */
     loading: boolean;
 }
 
 export function usePathway(): PathwayState {
     const { status } = useSession();
-    const loading = status === 'loading';
-    const isStudent = status === 'authenticated';
+    const authLoading = status === 'loading';
+    const isSignedIn = status === 'authenticated';
+
+    const [isAdmin, setIsAdmin] = useState(false);
+    const [adminChecked, setAdminChecked] = useState(false);
+    const [adminMode, setAdminModeState] = useState(false);
+
+    // Restore the persisted toggle once on mount.
+    useEffect(() => {
+        if (typeof window === 'undefined') return;
+        setAdminModeState(window.localStorage.getItem(ADMIN_MODE_KEY) === '1');
+    }, []);
+
+    // Resolve admin status from the server whenever the user signs in. Logged-out
+    // users are never admins; clear any stale flag.
+    useEffect(() => {
+        let cancelled = false;
+        if (!isSignedIn) {
+            setIsAdmin(false);
+            setAdminChecked(!authLoading);
+            return;
+        }
+        setAdminChecked(false);
+        (async () => {
+            try {
+                const res = await fetch('/api/admin/me');
+                const data = await res.json();
+                if (!cancelled) setIsAdmin(Boolean(data?.isAdmin));
+            } catch {
+                if (!cancelled) setIsAdmin(false);
+            } finally {
+                if (!cancelled) setAdminChecked(true);
+            }
+        })();
+        return () => {
+            cancelled = true;
+        };
+    }, [isSignedIn, authLoading]);
+
+    const setAdminMode = useCallback((on: boolean) => {
+        setAdminModeState(on);
+        if (typeof window !== 'undefined') {
+            if (on) window.localStorage.setItem(ADMIN_MODE_KEY, '1');
+            else window.localStorage.removeItem(ADMIN_MODE_KEY);
+        }
+    }, []);
+
+    // Admin mode only takes effect for a confirmed admin with the toggle on.
+    const isAdminMode = isAdmin && adminMode;
+    const isStudent = isSignedIn && !isAdminMode;
+    const pathway: Pathway = !isSignedIn ? 'guest' : isAdminMode ? 'admin' : 'student';
+
     return {
-        pathway: isStudent ? 'student' : 'guest',
+        pathway,
         isStudent,
-        isGuest: !isStudent,
-        loading,
+        isGuest: !isSignedIn,
+        isAdminMode,
+        isAdmin,
+        setAdminMode,
+        // Don't commit to a pathway until BOTH auth and the admin check resolve,
+        // so an admin with the toggle on never briefly renders the student view.
+        loading: authLoading || (isSignedIn && !adminChecked),
     };
 }


### PR DESCRIPTION
Follow-up to #16 — these two commits landed after #16 was merged, so `store-v2` is missing them. **#16 alone leaves HCB reconciliation broken** (the token blocker); the OAuth fix here is what makes guest donations actually reconcile.

## Commits
- `71ebcaa` — HCB checkout polish: prefill the donor's **name** on the HCB donation page (+ amount + email), and add an **"I've donated — check now"** button on the waiting screen alongside the auto-poll.
- `23f803c` — two related features:

### HCB authorization-code OAuth (fixes the token blocker)
The HCB app can't do `client_credentials` (verified against the live API — it 302s to a human login). So `lib/hcb.ts` now uses the **authorization-code grant**: an admin connects once, the refresh token is stored in Redis, and access tokens are minted/rotated from it. Reconciliation reads transactions with that token.
- New admin-gated routes: `GET /api/admin/hcb/connect` (→ HCB authorize, CSRF `state`), `POST /api/admin/hcb/callback` (code exchange), `GET/DELETE /api/admin/hcb/status`.
- `/hcb/callback` page now serves **both** the donor wait-screen (`?orderId=`) and the admin OAuth return (`?code=`).
- **HCB connection card on `/admin/finance`** (connect / reconnect / disconnect).

### Admin "buy everything" (opt-in)
- `usePathway` gains an `'admin'` pathway (admin status via `/api/admin/me`; opt-in toggle persisted in localStorage; off by default).
- Admins see the **full catalog** (points + cash items, both prices) and pick **points or HCB per order** at checkout.
- Cross-pathway buys convert at **1 point = $1**, enforced server-side for admins only (non-admins keep strict points-only / cash-only rules).

## Post-merge steps for HCB to actually work
1. The OAuth redirect_uri is `${NEXT_PUBLIC_API_URL}/hcb/callback` — must match the HCB app's registered callback (prod = `https://shop.hackclub.com/hcb/callback` ✅; a preview URL would need registering with HCB).
2. An admin clicks **Connect HCB** on `/admin/finance` once after deploy, then run one live test donation to confirm it flips to paid.

Until connected, guest donations can't reconcile and orders stay `unpaid` (safe). The admin **points** path works without HCB.

## Verification
`tsc --noEmit` clean · `next build` clean · `next lint` clean on all touched files. Live donation round-trip still needs the post-merge connect (can't authorize as a human from CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)